### PR TITLE
Optimise biquad double precision coprocessor code.

### DIFF
--- a/firmware/foxdac/dcp_inline.h
+++ b/firmware/foxdac/dcp_inline.h
@@ -25,6 +25,23 @@ static inline double dcp_dadd(double a, double b) {
     double r; memcpy(&r, &ur, 8); return r;
 }
 
+static inline float dcp_dadd_d2f(double a, double b) {
+    uint64_t ua, ub;
+    uint32_t ur;
+    memcpy(&ua, &a, 8); memcpy(&ub, &b, 8);
+    __asm__ volatile (
+        "mcrr p4, #1, %Q1, %R1, c0\n\t" // WXUP a
+        "mcrr p4, #1, %Q2, %R2, c1\n\t" // WYUP b
+        "cdp p4, #0, c0, c0, c1, #0\n\t" // ADD0
+        "cdp p4, #1, c0, c0, c1, #0\n\t" // ADD1
+        "cdp p4, #8, c0, c0, c2, #1\n\t" // NRDF
+        "mrc p4, #0, %0, c0, c2, #0\n\t" // RDFA result
+        : "=r" (ur)
+        : "r" (ua), "r" (ub)
+    );
+    float r; memcpy(&r, &ur, 4); return r;
+}
+
 static inline double dcp_dsub(double a, double b) {
     uint64_t ua, ub, ur;
     memcpy(&ua, &a, 8); memcpy(&ub, &b, 8);

--- a/firmware/foxdac/dsp_pipeline.c
+++ b/firmware/foxdac/dsp_pipeline.c
@@ -186,8 +186,7 @@ float dsp_process_channel(Biquad * __restrict biquads, float input, uint8_t chan
 
         // Mixed Precision: Float Multiplies, Double Accumulation
         // y[n] = b0*x[n] + s1[n-1]
-        double result_d = dcp_dadd(dcp_f2d(bq->b0 * sample), bq->s1);
-        float result_f = dcp_d2f(result_d);
+        float result_f = dcp_dadd_d2f(dcp_f2d(bq->b0 * sample), bq->s1);
 
         // s1[n] = b1*x[n] - a1*y[n] + s2[n-1]
         float val1 = bq->b1 * sample - bq->a1 * result_f;
@@ -226,8 +225,7 @@ void dsp_process_channel_block(Biquad * __restrict biquads, float * __restrict s
             float sample = samples[i];
 
             // y[n] = b0*x[n] + s1[n-1]
-            double result_d = dcp_dadd(dcp_f2d(b0 * sample), s1);
-            float result_f = dcp_d2f(result_d);
+            float result_f = dcp_dadd_d2f(dcp_f2d(b0 * sample), s1);
 
             // s1[n] = b1*x[n] - a1*y[n] + s2[n-1]
             float val1 = b1 * sample - a1 * result_f;


### PR DESCRIPTION
The double precision coprocessor (DCP) can return either a double or single precision result as required.

Add a new canned sequence dcp_dadd_d2f() which returns a single precision float after adding two double precision floats together. This avoids calling the coprocessor twice, once to do the addition and once to convert double to single precision.

Results in approximately 12% performance increase for the dsp_process_channel_block function.