### PR TITLE
Optimise double precision coprocessor calls for loudness compensation

### DIFF
--- a/firmware/foxdac/usb_audio.c
+++ b/firmware/foxdac/usb_audio.c
@@ -328,8 +328,7 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
                 const LoudnessCoeffs *lc = &loud_coeffs[j];
                 if (lc->bypass) continue;
                 Biquad *bq = &loudness_biquads[0][j];
-                double rd = dcp_dadd(dcp_f2d(lc->b0 * raw_left), bq->s1);
-                float rf = dcp_d2f(rd);
+                float rf = dcp_dadd_d2f(dcp_f2d(lc->b0 * raw_left), bq->s1);
                 float v1 = lc->b1 * raw_left - lc->a1 * rf;
                 bq->s1 = dcp_dadd(dcp_f2d(v1), bq->s2);
                 bq->s2 = dcp_f2d(lc->b2 * raw_left - lc->a2 * rf);
@@ -339,8 +338,7 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
                 const LoudnessCoeffs *lc = &loud_coeffs[j];
                 if (lc->bypass) continue;
                 Biquad *bq = &loudness_biquads[1][j];
-                double rd = dcp_dadd(dcp_f2d(lc->b0 * raw_right), bq->s1);
-                float rf = dcp_d2f(rd);
+                float rf = dcp_dadd_d2f(dcp_f2d(lc->b0 * raw_right), bq->s1);
                 float v1 = lc->b1 * raw_right - lc->a1 * rf;
                 bq->s1 = dcp_dadd(dcp_f2d(v1), bq->s2);
                 bq->s2 = dcp_f2d(lc->b2 * raw_right - lc->a2 * rf);


### PR DESCRIPTION
This really brings the biquad implementation into line with the change made in https://github.com/WeebLabs/DSPi/pull/17. Will be very slightly faster but not in a way that can be seen with the cpu usage meter in DSPi Console.