### PR TITLE
Add systick debug counters for core0

### DIFF
--- a/firmware/foxdac/CMakeLists.txt
+++ b/firmware/foxdac/CMakeLists.txt
@@ -23,6 +23,8 @@ add_executable(foxdac
     main.c
     pdm_generator.c
     pdm_generator.h
+    systick.c
+    systick.h
     usb_audio.c
     usb_audio.h
     usb_descriptors.c

--- a/firmware/foxdac/main.c
+++ b/firmware/foxdac/main.c
@@ -244,6 +244,8 @@ int main(void) {
 
     core0_init();
 
+    stdio_init_all();
+
     // Enable watchdog
     watchdog_enable(8000, 1);
 
@@ -315,6 +317,20 @@ int main(void) {
         if (++loop_counter >= 1000) {
             loop_counter = 0;
             gpio_xor_mask(1u << 25);
+        }
+
+        static uint32_t systick_print_counter = 0;
+        if(systick_print_counter++ > 10000000) {
+            printf("systick input convert      %u\n", systick_input_convert);
+            printf("systick loudness           %u\n", systick_loudness);
+            printf("systick master eq          %u\n", systick_master_eq);
+            printf("systick xfeed master peaks %u\n", systick_crossfeed_master_peaks);
+            printf("systick matrix mixer       %u\n", systick_matrix_mixer);
+            printf("systick output eq          %u\n", systick_output_eq);
+            printf("systick delay              %u\n", systick_delay);
+            printf("systick output peaks spdif %u\n", systick_peaks_spdif);
+            printf("\n");
+            systick_print_counter=0;
         }
     }
 }

--- a/firmware/foxdac/systick.c
+++ b/firmware/foxdac/systick.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+#include "systick.h"
+
+void start_systick()
+{
+    SysTick_RVR = SysTick_START;
+    SysTick_CVR = 0;
+    SysTick_CSR |=  (SysTick_Enable | SysTick_ClockSource);
+}
+
+uint32_t stop_systick()
+{
+    SysTick_CSR &= ~SysTick_Enable;
+
+    uint32_t cycles = (SysTick_START - SysTick_CVR);
+
+    if (SysTick_CSR & 0x10000)
+        printf("WARNING: counter has overflowed, more than 16,777,215 cycles");
+
+    return(cycles);
+}

--- a/firmware/foxdac/systick.h
+++ b/firmware/foxdac/systick.h
@@ -1,0 +1,15 @@
+#include <stdint.h>
+
+void start_systick(void);
+uint32_t stop_systick(void);
+
+/* SysTick variables */
+#define SysTick_BASE          (0xE000E000UL +  0x0010UL)
+#define SysTick_START         0xFFFFFF
+
+#define SysTick_CSR           (*((volatile uint32_t*)(SysTick_BASE + 0x0UL)))
+#define SysTick_RVR           (*((volatile uint32_t*)(SysTick_BASE + 0x4UL)))
+#define SysTick_CVR           (*((volatile uint32_t*)(SysTick_BASE + 0x8UL)))
+
+#define SysTick_Enable        0x1
+#define SysTick_ClockSource   0x4

--- a/firmware/foxdac/usb_audio.c
+++ b/firmware/foxdac/usb_audio.c
@@ -110,6 +110,16 @@ struct audio_format audio_format_48k = { .format = AUDIO_BUFFER_FORMAT_PCM_S16, 
 #define producer_pool producer_pool_1
 #define sub_producer_pool producer_pool_2
 
+// Systick counters
+volatile uint32_t systick_input_convert = 0;
+volatile uint32_t systick_loudness = 0;
+volatile uint32_t systick_master_eq = 0;
+volatile uint32_t systick_crossfeed_master_peaks = 0;
+volatile uint32_t systick_matrix_mixer = 0;
+volatile uint32_t systick_output_eq = 0;
+volatile uint32_t systick_delay = 0;
+volatile uint32_t systick_peaks_spdif = 0;
+
 // ----------------------------------------------------------------------------
 // USB INTERFACE / ENDPOINT OBJECTS
 // ----------------------------------------------------------------------------
@@ -329,12 +339,15 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
     static float buf_l[192], buf_r[192];
 
     // ========== PASS 1: Input conversion + Preamp + Loudness ==========
+    start_systick();
     for (uint32_t i = 0; i < sample_count; i++) {
         buf_l[i] = (float)in[i*2] * inv_32768 * preamp;
         buf_r[i] = (float)in[i*2+1] * inv_32768 * preamp;
     }
+    systick_input_convert = stop_systick();
 
     // Loudness compensation
+    start_systick();
     if (loud_on && loud_coeffs) {
         for (uint32_t i = 0; i < sample_count; i++) {
             float raw_left = buf_l[i];
@@ -365,8 +378,10 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
             buf_r[i] = raw_right;
         }
     }
+    systick_loudness = stop_systick();
 
     // ========== PASS 2: Master EQ (Block-Based) ==========
+    start_systick();
     if (!is_bypassed) {
         if (!channel_bypassed[CH_MASTER_LEFT]) {
             dsp_process_channel_block(filters[CH_MASTER_LEFT], buf_l, sample_count, CH_MASTER_LEFT);
@@ -375,8 +390,10 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
             dsp_process_channel_block(filters[CH_MASTER_RIGHT], buf_r, sample_count, CH_MASTER_RIGHT);
         }
     }
+    systick_master_eq = stop_systick();
 
     // ========== PASS 3: Crossfeed + Master Peaks ==========
+    start_systick();
     bool do_crossfeed = !crossfeed_bypassed;
 
     // Crossfeed is sample-by-sample (internal state), combined with peak tracking
@@ -389,9 +406,11 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
             buf_l[i] = ml; buf_r[i] = mr;
         }
     }
+    systick_crossfeed_master_peaks = stop_systick();
 
     // ========== PASS 4: Matrix Mixing (block-based, output-major) ==========
     // Snapshot crosspoint coefficients and process one output at a time
+    start_systick();
     for (int out = 0; out < NUM_OUTPUT_CHANNELS; out++) {
         if (!matrix_mixer.outputs[out].enabled) {
             memset(buf_out[out], 0, sample_count * sizeof(float));
@@ -419,6 +438,7 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
             memset(dst, 0, sample_count * sizeof(float));
         }
     }
+    systick_matrix_mixer = stop_systick();
 
     // ========== PASS 5-7: Per-Output EQ + Gain + Delay + Output ==========
     if (core1_mode == CORE1_MODE_EQ_WORKER) {
@@ -437,6 +457,7 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
         __sev();
 
         // Core 0: EQ + gain for outputs 0-1
+        start_systick();
         for (int out = 0; out < CORE1_EQ_FIRST_OUTPUT; out++) {
             if (!matrix_mixer.outputs[out].enabled) continue;
             if (!matrix_mixer.outputs[out].mute) {
@@ -455,8 +476,10 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
                     dst[i] *= gain;
             }
         }
+        systick_output_eq = stop_systick();
 
         // Core 0: Delay for outputs 0-1
+        start_systick();
         if (any_delay_active) {
             for (int out = 0; out < CORE1_EQ_FIRST_OUTPUT; out++) {
                 int32_t dly = channel_delay_samples[out];
@@ -471,8 +494,10 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
                 }
             }
         }
+        systick_delay = stop_systick();
 
         // Core 0: Peaks + S/PDIF for pair 0
+        start_systick();
         for (uint32_t i = 0; i < sample_count; i++) {
             float abs_ol = fabsf(buf_out[0][i]); if (abs_ol > peak_ol) peak_ol = abs_ol;
             float abs_or = fabsf(buf_out[1][i]); if (abs_or > peak_or) peak_or = abs_or;
@@ -491,6 +516,7 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
                 }
             }
         }
+        systick_peaks_spdif = stop_systick();
 
         // Wait for Core 1 (EQ + delay + S/PDIF for outputs 2-7)
         while (!core1_eq_work.work_done) {
@@ -506,6 +532,7 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
         // --- Single-core path: all outputs on Core 0 ---
 
         // EQ + gain
+        start_systick();
         for (int out = 0; out < NUM_OUTPUT_CHANNELS; out++) {
             if (!matrix_mixer.outputs[out].enabled) continue;
             if (!matrix_mixer.outputs[out].mute) {
@@ -524,8 +551,10 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
                     dst[i] *= gain;
             }
         }
+        systick_output_eq = stop_systick();
 
         // Delay
+        start_systick();
         if (any_delay_active) {
             for (int out = 0; out < NUM_OUTPUT_CHANNELS; out++) {
                 int32_t dly = channel_delay_samples[out];
@@ -541,8 +570,10 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
             }
             delay_write_idx = (delay_write_idx + sample_count) & MAX_DELAY_MASK;
         }
+        systick_delay = stop_systick();
 
         // Peaks (first stereo pair only)
+        start_systick();
         for (uint32_t i = 0; i < sample_count; i++) {
             float abs_ol = fabsf(buf_out[0][i]); if (abs_ol > peak_ol) peak_ol = abs_ol;
             float abs_or = fabsf(buf_out[1][i]); if (abs_or > peak_or) peak_or = abs_or;
@@ -565,6 +596,7 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
                 out_ptr[i*2+1]   = (int16_t)(dr * 32767.0f);
             }
         }
+        systick_peaks_spdif = stop_systick();
 
 #if ENABLE_SUB
         if (matrix_mixer.outputs[NUM_OUTPUT_CHANNELS-1].enabled) {
@@ -606,14 +638,17 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
     static int32_t buf_l[192], buf_r[192];
 
     // ========== PASS 1: Input conversion + Preamp + Loudness ==========
+    start_systick();
     for (uint32_t i = 0; i < sample_count; i++) {
         int32_t raw_left_32 = (int32_t)in[i*2] << 14;
         int32_t raw_right_32 = (int32_t)in[i*2+1] << 14;
         buf_l[i] = fast_mul_q28(raw_left_32, preamp);
         buf_r[i] = fast_mul_q28(raw_right_32, preamp);
     }
+    systick_input_convert = stop_systick();
 
     // Loudness compensation (per-sample — biquad state coupling)
+    start_systick();
     if (loud_on && loud_coeffs) {
         for (uint32_t i = 0; i < sample_count; i++) {
             int32_t raw_left_32 = buf_l[i];
@@ -644,16 +679,20 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
             buf_r[i] = raw_right_32;
         }
     }
+    systick_loudness = stop_systick();
 
     // ========== PASS 2: Master EQ (Block-Based) ==========
+    start_systick()
     if (!is_bypassed) {
         if (!channel_bypassed[CH_MASTER_LEFT])
             dsp_process_channel_block(filters[CH_MASTER_LEFT], buf_l, sample_count, CH_MASTER_LEFT);
         if (!channel_bypassed[CH_MASTER_RIGHT])
             dsp_process_channel_block(filters[CH_MASTER_RIGHT], buf_r, sample_count, CH_MASTER_RIGHT);
     }
+    systick_master_eq = stop_systick();
 
     // ========== PASS 3: Crossfeed + Master Peaks ==========
+    start_systick();
     for (uint32_t i = 0; i < sample_count; i++) {
         int32_t ml = buf_l[i], mr = buf_r[i];
         if (abs(ml) > peak_ml) peak_ml = abs(ml);
@@ -663,8 +702,10 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
             buf_l[i] = ml; buf_r[i] = mr;
         }
     }
+    systick_crossfeed_master_peaks = stop_systick();
 
     // ========== PASS 4: Matrix Mixing (block-based, output-major) ==========
+    start_systick();
     for (int out = 0; out < NUM_OUTPUT_CHANNELS; out++) {
         if (!matrix_mixer.outputs[out].enabled) {
             memset(buf_out[out], 0, sample_count * sizeof(int32_t));
@@ -690,6 +731,7 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
             memset(dst, 0, sample_count * sizeof(int32_t));
         }
     }
+    systick_matrix_mixer = stop_systick();
 
     // ========== PASS 5-7: Per-Output EQ + Gain + Delay + Output ==========
     // PDM output index
@@ -709,6 +751,7 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
         __sev();
 
         // Core 0: EQ + gain for outputs 0-1 (SPDIF pair 1)
+        start_systick();
         for (int out = 0; out < CORE1_EQ_FIRST_OUTPUT; out++) {
             if (!matrix_mixer.outputs[out].enabled) continue;
             if (!matrix_mixer.outputs[out].mute) {
@@ -726,8 +769,10 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
                     dst[i] = fast_mul_q15(dst[i], gain);
             }
         }
+        systick_output_eq = stop_systick();
 
         // Core 0: Delay for outputs 0-1
+        start_systick();
         if (any_delay_active) {
             for (int out = 0; out < CORE1_EQ_FIRST_OUTPUT; out++) {
                 int32_t dly = channel_delay_samples[out];
@@ -742,8 +787,10 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
                 }
             }
         }
+        systick_delay = stop_systick();
 
         // Core 0: Peaks + S/PDIF conversion for pair 1
+        start_systick();
         for (uint32_t i = 0; i < sample_count; i++) {
             if (abs(buf_out[0][i]) > peak_ol) peak_ol = abs(buf_out[0][i]);
             if (abs(buf_out[1][i]) > peak_or) peak_or = abs(buf_out[1][i]);
@@ -759,6 +806,7 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
                 }
             }
         }
+        systick_peaks_spdif = stop_systick();
 
         // Wait for Core 1 (EQ + delay + S/PDIF for outputs 2-3)
         while (!core1_eq_work.work_done) {
@@ -775,6 +823,7 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
         uint32_t saved_delay_write_idx = delay_write_idx;
 
         // EQ + gain (block-based)
+        start_systick();
         for (int out = 0; out < NUM_OUTPUT_CHANNELS; out++) {
             if (!matrix_mixer.outputs[out].enabled) continue;
             if (!matrix_mixer.outputs[out].mute) {
@@ -792,8 +841,10 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
                     dst[i] = fast_mul_q15(dst[i], gain);
             }
         }
+        systick_output_eq = stop_systick();
 
         // Delay (all outputs use same base write index)
+        start_systick();
         if (any_delay_active) {
             for (int out = 0; out < NUM_OUTPUT_CHANNELS; out++) {
                 int32_t dly = channel_delay_samples[out];
@@ -809,8 +860,10 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
             }
             delay_write_idx = (saved_delay_write_idx + sample_count) & MAX_DELAY_MASK;
         }
+        systick_delay = stop_systick();
 
         // Peaks (first stereo pair + sub)
+        start_systick();
         for (uint32_t i = 0; i < sample_count; i++) {
             if (abs(buf_out[0][i]) > peak_ol) peak_ol = abs(buf_out[0][i]);
             if (abs(buf_out[1][i]) > peak_or) peak_or = abs(buf_out[1][i]);
@@ -831,6 +884,7 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
                 out_ptr[i*2+1] = (int16_t)(clip_s32(buf_out[right_ch][i] + (1<<13)) >> 14);
             }
         }
+        systick_peaks_spdif = stop_systick();
 
 #if ENABLE_SUB
         // PDM sub output

--- a/firmware/foxdac/usb_audio.h
+++ b/firmware/foxdac/usb_audio.h
@@ -7,6 +7,7 @@
 #define USB_AUDIO_H
 
 #include "config.h"
+#include "systick.h"
 
 // ----------------------------------------------------------------------------
 // AUDIO STATE (exposed to Main)
@@ -52,6 +53,20 @@ extern volatile bool eq_update_pending;
 extern volatile EqParamPacket pending_packet;
 extern volatile bool rate_change_pending;
 extern volatile uint32_t pending_rate;
+
+// ----------------------------------------------------------------------------
+// Systick counters
+// ----------------------------------------------------------------------------
+
+extern volatile uint32_t systick_input_convert;
+extern volatile uint32_t systick_loudness;
+extern volatile uint32_t systick_master_eq;
+extern volatile uint32_t systick_crossfeed_master_peaks;
+extern volatile uint32_t systick_matrix_mixer;
+extern volatile uint32_t systick_output_eq;
+extern volatile uint32_t systick_delay;
+extern volatile uint32_t systick_peaks_spdif;
+
 
 // ----------------------------------------------------------------------------
 // API


### PR DESCRIPTION
It is not very easy to get detailed insight into the code performance using the cpu meter. The rpi debug probe can be used with openocd program counter sampling but putting the resulting gprof data through arm-none-eabi-gprof doesnt give particularly good results.

As we know where the expensive code is, it can be instrumented in-place instead using the systick counter.

Currently this prints once per second on the RP2350 uart, but I don't have a RP2040 to test it with unfortunately. Ideally it would respond to a keypress on the uart and print the systick data, but I've not yet found a way to do a non-blocking read of the uart through the pico stdlib/sdk.