### PR TITLE
Fix REQ_GET_EQ_PARAM documentation to match firmware wire format

### DIFF
--- a/Documentation/Features/master_volume_spec.md
+++ b/Documentation/Features/master_volume_spec.md
@@ -67,7 +67,7 @@ Critically, the master volume does not change the value that loudness compensati
 |----------|-------|
 | **Type** | `float` (IEEE 754 single-precision) |
 | **Range** | -128.0 (mute) to 0.0 (unity) |
-| **Default** | 0.0 (unity -- no attenuation) |
+| **Default** | -20.0 (power-on / fresh-device default; see `MASTER_VOL_DEFAULT_DB`) |
 | **SET command** | `0xD2` (`REQ_SET_MASTER_VOLUME`) |
 | **GET command** | `0xD3` (`REQ_GET_MASTER_VOLUME`) |
 | **Payload** | 4 bytes: little-endian IEEE 754 float |
@@ -398,13 +398,13 @@ Fresh-device directory defaults:
 | Parameter | Default value |
 |-----------|---------------|
 | master_volume_mode | 0 (independent) |
-| master_volume_db (directory) | 0.0 (unity) |
+| master_volume_db (directory) | -20.0 (see `MASTER_VOL_DEFAULT_DB`) |
 
 ### Boot behavior
 
 On device startup:
-1. Live `master_volume_db` starts at 0.0 dB (unity) from the static initializer.
-2. Directory is loaded. If directory is v1 (pre-refactor), it's migrated to v2 in-place; the old `include_master_volume` flag maps 1:1 to `master_volume_mode`, and `PresetDirectory.master_volume_db` defaults to 0.0 dB so boot-time audible behavior is unchanged for upgraded devices.
+1. Live `master_volume_db` starts at -20.0 dB (`MASTER_VOL_DEFAULT_DB`) from the static initializer, with matching precomputed linear (0.1) and Q15 (3277) values. This only matters for the tiny window before preset_boot_load runs.
+2. Directory is loaded. If directory is v1 (pre-refactor), it's migrated to v2 in-place; the old `include_master_volume` flag maps 1:1 to `master_volume_mode`, and `PresetDirectory.master_volume_db` is set to `MASTER_VOL_DEFAULT_DB` (-20 dB). Upgraded devices in mode 0 boot at -20 dB instead of their previous 0 dB — quieter, not louder, so the change is safe. Mode 1 upgraders are unaffected (they read master volume from the preset slot).
 3. The preset system loads the startup slot (per the startup policy).
 4. Master volume is applied based on mode:
    - **Mode 0:** `PresetDirectory.master_volume_db` is applied to live globals — the device comes up at the user's last-saved independent value.
@@ -602,12 +602,12 @@ Devices running firmware built before the mode-flag refactor have a `PresetDirec
 1. `dir_load_cache` reads the directory's magic + version from the fixed 12-byte header.
 2. If `version == 1`, the directory is read with a local `PresetDirectory_v1` struct, its v1-sized CRC is validated, and the field values are copied into the new v2 cache:
    - `master_volume_mode` = old `include_master_volume` (direct 1:1 map — `0` stays `0` meaning "independent" with default 0 dB, `1` stays `1` meaning "with preset")
-   - `master_volume_db` = 0.0 dB (unity)
+   - `master_volume_db` = -20.0 dB (`MASTER_VOL_DEFAULT_DB`)
    - All other fields (slot names, startup mode, default slot, last active, include_pins, slot occupancy) copied verbatim
 3. The migrated cache is flushed to flash as `version = 2`. The migration is transparent and one-shot.
 4. If the v1 CRC fails to validate, the fresh-directory path runs — identical to a first-ever boot. User-visible directory state (slot names, startup config, slot occupancy) would be lost, but slot contents remain intact.
 
-Audible behavior is unchanged across the upgrade: old `include_master_volume == 0` devices boot at 0 dB (unity) in both the old and new firmware; old `include_master_volume == 1` devices continue to restore master volume from each loaded preset.
+Behavior across the upgrade: old `include_master_volume == 1` devices continue to restore master volume from each loaded preset, unchanged. Old `include_master_volume == 0` devices previously booted at 0 dB (unity); after upgrade they boot at `MASTER_VOL_DEFAULT_DB` (-20 dB) until the user issues `REQ_SAVE_MASTER_VOLUME` to persist a different value. Quieter, safer — not louder.
 
 ### Old apps with new firmware
 

--- a/Documentation/Features/master_volume_spec.md
+++ b/Documentation/Features/master_volume_spec.md
@@ -82,30 +82,35 @@ The master volume level in decibels. This is an attenuation-only control:
 
 Values below -128.0 are clamped to -128.0 (mute). Values above 0.0 are clamped to 0.0 (unity). NaN and infinity values are silently rejected (the master volume is left unchanged).
 
-### 2.2 include_master_volume
+### 2.2 master_volume_mode
 
 | Property | Value |
 |----------|-------|
-| **Type** | `uint8_t` (bool) |
-| **Range** | 0 (don't restore) or 1 (restore) |
-| **Default** | 0 (don't restore on preset load) |
-| **SET command** | `0xD4` (`REQ_SET_INCLUDE_MASTER_VOL`) |
-| **GET command** | `0xD5` (`REQ_GET_INCLUDE_MASTER_VOL`) |
+| **Type** | `uint8_t` |
+| **Range** | 0 (independent) or 1 (with preset) |
+| **Default** | 0 (independent) |
+| **SET command** | `0xD4` (`REQ_SET_MASTER_VOLUME_MODE`) |
+| **GET command** | `0xD5` (`REQ_GET_MASTER_VOLUME_MODE`) |
 | **Payload** | 1 byte |
 
-Controls whether loading a preset also restores the master volume from that preset's saved state. This is a **directory-level** flag (global setting, not per-preset), mirroring the `include_pins` pattern.
+Selects how master volume is persisted across boots. This is a **directory-level** setting (global, not per-preset), mirroring `include_pins`.
 
-- **0 (default):** Preset loads do not change the master volume. The master volume behaves like a physical volume knob -- it stays where the user set it regardless of preset switching.
-- **1:** Preset loads restore the master volume from the preset. Useful when different presets target different speaker setups at different maximum output levels.
+- **Mode 0 — Independent (default).** Master volume is a stand-alone device setting, saved in the preset directory, applied at boot, and completely unaffected by preset save/load. The app persists a chosen value by issuing `REQ_SAVE_MASTER_VOLUME` (0xD6); the device then boots at that value on subsequent power-ups. Preset save still writes `master_volume_db` into the slot (so the same flash layout works for either mode), but the saved slot value is ignored on load. Behaves like a physical volume knob: preset switching never moves the knob.
+- **Mode 1 — With preset.** Master volume is part of the preset. Saved with the preset, restored on preset load, same as other DSP parameters. Useful when different presets target different speaker setups at different maximum output levels.
 
-This flag is stored in the preset directory (flash) and persists across reboots. Setting this flag triggers a deferred flash write via the main loop.
+Values outside `[0, 1]` are clamped to 0. Setting the mode triggers a deferred flash write via the main loop. The value itself persists in the preset directory across reboots.
+
+### 2.3 saved master volume (independent storage)
+
+The directory sector also carries a `master_volume_db` field — the value applied at boot when mode is 0. Updated by `REQ_SAVE_MASTER_VOLUME` (copies the current live `master_volume_db` into the field and flushes the directory). Readable via `REQ_GET_SAVED_MASTER_VOLUME`. The save command is accepted in both modes; in mode 1 the stored value is dormant until the user switches to mode 0.
 
 ### Parameter summary
 
 | Parameter | Type | Range | Default | SET | GET | Payload |
 |-----------|------|-------|---------|-----|-----|---------|
-| master_volume_db | float | -128.0 to 0.0 | 0.0 | 0xD2 | 0xD3 | 4 bytes (LE float) |
-| include_master_volume | uint8_t | 0/1 | 0 | 0xD4 | 0xD5 | 1 byte |
+| master_volume_db (live) | float | -128.0 to 0.0 | 0.0 | 0xD2 | 0xD3 | 4 bytes (LE float) |
+| master_volume_mode | uint8_t | 0/1 | 0 | 0xD4 | 0xD5 | 1 byte |
+| saved master volume | float | -128.0 to 0.0 | 0.0 | 0xD6 (no payload, uses live) | 0xD7 | 4 bytes (LE float) |
 
 ### Constants
 
@@ -183,7 +188,7 @@ Returns the current master volume in dB. Returns -128.0 if muted, or a value in 
 [0x00, 0x00, 0x00, 0xC3]   (-128.0f)
 ```
 
-### 3.3 REQ_SET_INCLUDE_MASTER_VOL (0xD4)
+### 3.3 REQ_SET_MASTER_VOLUME_MODE (0xD4)
 
 | Field | Value |
 |-------|-------|
@@ -192,22 +197,23 @@ Returns the current master volume in dB. Returns -128.0 if muted, or a value in 
 | **wValue** | Unused (0) |
 | **wIndex** | Unused (0) |
 | **wLength** | 1 |
-| **Payload** | 1 byte: `0x00` = don't restore, nonzero = restore |
+| **Payload** | 1 byte: `0x00` = independent (default), `0x01` = with preset |
 
 **Firmware behavior:**
 1. Reads byte 0 from the vendor receive buffer.
-2. Updates the `include_master_volume` flag in the directory cache.
-3. Sets a pending flag for a deferred flash write on the next main loop iteration.
+2. Clamps values outside `[0, 1]` to `0`.
+3. Updates the `master_volume_mode` field in the directory cache.
+4. Sets a pending flag for a deferred flash write on the next main loop iteration.
 
 **Validation:** Minimum payload length = 1 byte. Shorter payloads are silently ignored.
 
-**Example:** Enable master volume restore on preset load:
+**Example:** Switch to mode 1 (volume lives inside presets):
 ```
 bRequest = 0xD4, wValue = 0x0000, wIndex = 0x0000, wLength = 1
 Payload: [0x01]
 ```
 
-### 3.4 REQ_GET_INCLUDE_MASTER_VOL (0xD5)
+### 3.4 REQ_GET_MASTER_VOLUME_MODE (0xD5)
 
 | Field | Value |
 |-------|-------|
@@ -216,11 +222,54 @@ Payload: [0x01]
 | **wValue** | Unused (0) |
 | **wIndex** | Unused (0) |
 | **wLength** | 1 |
-| **Response** | 1 byte: `0x00` = don't restore, `0x01` = restore |
+| **Response** | 1 byte: `0x00` = independent, `0x01` = with preset |
 
-**Example response** (include_master_volume disabled, default):
+**Example response** (default, mode 0):
 ```
 [0x00]
+```
+
+### 3.5 REQ_SAVE_MASTER_VOLUME (0xD6)
+
+| Field | Value |
+|-------|-------|
+| **Direction** | Host -> Device (OUT) |
+| **bRequest** | `0xD6` |
+| **wValue** | Unused (0) |
+| **wIndex** | Unused (0) |
+| **wLength** | 0 |
+| **Payload** | None |
+
+Copies the current live `master_volume_db` into the directory's independent storage field and flushes the directory sector to flash. This is the command that makes a chosen master volume survive a power cycle in mode 0.
+
+**Firmware behavior:**
+1. Sets a pending flag for a deferred flash write on the next main loop iteration.
+2. Main loop captures the then-current live `master_volume_db` value and writes it to the directory.
+3. No value is returned; the transfer completes once the command is accepted.
+
+**Accepted in both modes.** In mode 1 the stored value is dormant until the user switches to mode 0, so the app can issue this command regardless of mode without a pre-check. No error is surfaced for a "wrong mode" — the write simply becomes inert.
+
+**Example:** Persist the currently active master volume:
+```
+bRequest = 0xD6, wValue = 0x0000, wIndex = 0x0000, wLength = 0
+```
+
+### 3.6 REQ_GET_SAVED_MASTER_VOLUME (0xD7)
+
+| Field | Value |
+|-------|-------|
+| **Direction** | Device -> Host (IN) |
+| **bRequest** | `0xD7` |
+| **wValue** | Unused (0) |
+| **wIndex** | Unused (0) |
+| **wLength** | 4 |
+| **Response** | 4 bytes: IEEE 754 float, little-endian |
+
+Returns the value stored in the directory's independent master-volume field — i.e., the value the device would apply at boot in mode 0. Independent of the current live value and the current mode. Useful for showing "saved value" and "current value" side by side in the UI, or offering a "revert" button.
+
+**Example response** (saved value is -12.0 dB):
+```
+[0x00, 0x00, 0x40, 0xC1]   (-12.0f)
 ```
 
 ---
@@ -273,7 +322,7 @@ When the firmware receives a SET (0xA1) with `format_version` < 6, master volume
 
 When the firmware sends a GET (0xA0), the `WireMasterVolume` section is always populated with the current value and `format_version` is set to the current version.
 
-**Bulk SET behavior:** The master volume from a bulk SET is always applied, regardless of the `include_master_volume` directory flag. The directory flag only governs preset loads. Bulk SET is a full state replacement and always applies all fields.
+**Bulk SET behavior:** The master volume from a bulk SET is always applied to the live `master_volume_db` global, regardless of `master_volume_mode`. Bulk SET is an in-memory state push — it does not touch the directory's independent storage field (that requires an explicit `REQ_SAVE_MASTER_VOLUME`). Mode 0 users who want a bulk-pushed value to survive a reboot must follow the bulk SET with a `REQ_SAVE_MASTER_VOLUME`.
 
 ### Bulk transfer commands
 
@@ -286,11 +335,12 @@ When the firmware sends a GET (0xA0), the `WireMasterVolume` section is always p
 
 ## 5. Preset Persistence
 
-Master volume is saved and restored as part of the user preset system, with a directory-level flag controlling whether preset loads actually restore the master volume.
+Master volume has two persistence models selectable at runtime via `master_volume_mode`. In mode 0 (default) it lives in the preset directory sector, independent of presets. In mode 1 it lives in the individual preset slots, saved and restored with each preset.
 
 ### Flash storage version
 
-The master volume field was added to the `PresetSlot` struct at `SLOT_DATA_VERSION` 12.
+- `PresetSlot.master_volume_db` was added at `SLOT_DATA_VERSION` 12. Still saved on every preset save (see below).
+- `PresetDirectory.master_volume_db` — the independent storage — was added at directory `version = 2`. Directory v1 (pre-refactor) is migrated transparently on first boot of new firmware (see Section 7).
 
 ### PresetSlot fields
 
@@ -300,45 +350,70 @@ The following field is appended to the `PresetSlot` struct:
 |-------|------|------|-------------|
 | `master_volume_db` | float | 4 | -128.0 (mute) to 0.0 dB |
 
-### Save behavior
+### PresetDirectory fields (relevant to master volume)
 
-When `REQ_PRESET_SAVE` (0x90) is issued, the current master volume is **always** saved into the preset slot, regardless of the `include_master_volume` flag:
+At `version = 2`:
+
+| Field | Type | Size | Description |
+|-------|------|------|-------------|
+| `master_volume_mode` | uint8_t | 1 | 0 = independent, 1 = with preset |
+| `master_volume_db` | float | 4 | Saved independent value (mode 0 source) |
+
+### Save behavior (preset save)
+
+When `REQ_PRESET_SAVE` (0x90) is issued, the current live master volume is **always** saved into the preset slot, regardless of mode:
 
 ```
 slot->master_volume_db = master_volume_db;
 ```
 
-This ensures the preset always contains a complete snapshot of the device state. The `include_master_volume` flag only controls whether the saved value is restored on load.
+This ensures the preset always contains a complete snapshot of the device state. In mode 0 the saved value is simply ignored on load; in mode 1 it's the source of truth on load.
 
-### Load behavior
+### Save behavior (independent storage, mode 0)
 
-When `REQ_PRESET_LOAD` (0x91) is issued:
+When `REQ_SAVE_MASTER_VOLUME` (0xD6) is issued, the current live master volume is copied to `PresetDirectory.master_volume_db` and the directory sector is flushed to flash. This is the write that makes the chosen volume survive a power cycle in mode 0. Issuing this command in mode 1 is accepted but dormant (see Section 3.5).
 
-- **Slot version >= 12 AND `include_master_volume` == 1:** Master volume is restored from the slot data.
-- **Slot version >= 12 AND `include_master_volume` == 0:** Master volume is left unchanged (the current live value persists).
-- **Slot version < 12:** Master volume is left unchanged (the slot predates master volume support).
-- **Unconfigured (empty) slot:** Factory defaults are applied; master volume is set to 0.0 dB only if `include_master_volume` == 1.
+### Load behavior (preset load)
+
+When `REQ_PRESET_LOAD` (0x91) is issued, master volume is applied as follows:
+
+- **Mode 1 AND slot version >= 12:** Master volume is restored from `slot->master_volume_db`.
+- **Mode 1 AND slot version < 12:** Master volume falls back to `PresetDirectory.master_volume_db` (the slot predates master volume support, so there's nothing to restore).
+- **Mode 0 (any slot version):** Master volume is **not** touched by the slot data. Live `master_volume_db` persists at whatever it currently is. (Factory-defaults paths explicitly re-apply `PresetDirectory.master_volume_db`; see below.)
+- **Unconfigured (empty) slot:** Factory defaults are applied. The master-volume portion of factory defaults defers to the mode-aware helper, so mode 0 restores `PresetDirectory.master_volume_db` and mode 1 falls back to the same directory value (since there's no slot).
 
 ### Factory defaults
 
-Applied on factory reset (`REQ_FACTORY_RESET` / 0x53):
+Applied on factory reset (`REQ_FACTORY_RESET` / 0x53) and on loading an empty or corrupt slot:
+
+| Path | master_volume_db applied |
+|------|--------------------------|
+| Factory reset, mode 0 | `PresetDirectory.master_volume_db` (preserves user's saved independent value) |
+| Factory reset, mode 1 | `PresetDirectory.master_volume_db` (fallback; defaults to 0.0 dB) |
+
+The directory's `master_volume_mode` and `master_volume_db` fields are **not** reset by a factory reset — factory reset only touches live DSP state, not directory metadata.
+
+Fresh-device directory defaults:
 
 | Parameter | Default value |
 |-----------|---------------|
-| master_volume_db | 0.0 (unity) |
-| include_master_volume | 0 (don't restore) |
+| master_volume_mode | 0 (independent) |
+| master_volume_db (directory) | 0.0 (unity) |
 
 ### Boot behavior
 
 On device startup:
-1. Master volume is initialized to 0.0 dB (unity).
-2. The preset system loads the startup slot (per the startup policy).
-3. If the slot contains V12+ data and `include_master_volume` is set, master volume is restored from the slot.
-4. Otherwise, master volume remains at 0.0 dB.
+1. Live `master_volume_db` starts at 0.0 dB (unity) from the static initializer.
+2. Directory is loaded. If directory is v1 (pre-refactor), it's migrated to v2 in-place; the old `include_master_volume` flag maps 1:1 to `master_volume_mode`, and `PresetDirectory.master_volume_db` defaults to 0.0 dB so boot-time audible behavior is unchanged for upgraded devices.
+3. The preset system loads the startup slot (per the startup policy).
+4. Master volume is applied based on mode:
+   - **Mode 0:** `PresetDirectory.master_volume_db` is applied to live globals — the device comes up at the user's last-saved independent value.
+   - **Mode 1 AND slot V12+:** `slot->master_volume_db` is applied.
+   - **Mode 1 AND slot older:** `PresetDirectory.master_volume_db` is applied as fallback.
 
 ### Preset directory response
 
-The `REQ_PRESET_GET_DIR` (0x95) response now includes a 7th byte for the `include_master_volume` flag:
+The `REQ_PRESET_GET_DIR` (0x95) response is still 7 bytes; byte [6] now carries `master_volume_mode` instead of `include_master_volume`. The numeric value space is unchanged (0 or 1):
 
 | Byte | Field | Description |
 |------|-------|-------------|
@@ -347,9 +422,9 @@ The `REQ_PRESET_GET_DIR` (0x95) response now includes a 7th byte for the `includ
 | 3 | `default_slot` | Default startup slot index (0-9) |
 | 4 | `last_active_slot` | Last active slot index (0-9) |
 | 5 | `include_pins` | 0 = don't restore pins on load, 1 = restore |
-| 6 | `include_master_volume` | 0 = don't restore master volume on load, 1 = restore |
+| 6 | `master_volume_mode` | 0 = independent, 1 = with preset |
 
-**Backward compatibility:** Apps requesting 6 bytes (the pre-V12 directory size) will receive only the first 6 bytes. USB control transfers naturally truncate to the requested `wLength`. No error occurs; the app simply does not see the new byte.
+Apps requesting the old 6-byte size still work (USB truncates to `wLength`). Apps that want the mode byte must request `wLength >= 7`. The renamed field at byte [6] is numerically compatible with apps written for `include_master_volume`: value 1 still means "preset restores master volume" in both interpretations, and value 0 still means "preset does not restore" (with the new semantic that the device instead applies an independent stored value at boot).
 
 ---
 
@@ -371,13 +446,14 @@ GET 0xD3 -> master_volume_db  (4 bytes, float)
 
 Issue `REQ_GET_ALL_PARAMS` (0xA0). The response is a `WireBulkParams` struct (2896 bytes). Parse the `WireMasterVolume` at byte offset 2880 (the last 16 bytes). Check `header.format_version >= 6`; if the format version is older, master volume is not present and should be displayed as 0.0 dB.
 
-Also read the directory flag:
+Also read the mode and the saved independent value:
 
 ```
-GET 0xD5 -> include_master_volume  (1 byte)
+GET 0xD5 -> master_volume_mode          (1 byte; 0 = independent, 1 = with preset)
+GET 0xD7 -> saved_master_volume_db      (4 bytes; float)
 ```
 
-Or parse byte 6 of the `REQ_PRESET_GET_DIR` (0x95) response (request `wLength = 7`).
+Or parse byte 6 of the `REQ_PRESET_GET_DIR` (0x95) response (request `wLength = 7`) for `master_volume_mode`.
 
 ### Step 2: Build the UI
 
@@ -404,11 +480,12 @@ float db_to_slider(float db) {
 }
 ```
 
-**Include master volume toggle:**
-- A checkbox or toggle in a settings/preferences area
-- Label: "Restore master volume on preset load"
-- Default: off
-- When enabled, switching presets may change the output volume
+**Master volume mode selector:**
+- A two-state control in a settings/preferences area
+- Option 0 (default): "Master volume is independent of presets"
+- Option 1: "Master volume is part of each preset"
+- Consider offering a "Save as boot default" button next to the volume slider. In mode 0 this button is the primary way to persist the current volume; in mode 1 it still works (writes to the independent storage) but is less meaningful until the user switches modes.
+- A "Revert to saved" button can call `GET 0xD7` and then `SET 0xD2` to pull the stored value back into the live state.
 
 ### Step 3: Send SET commands on user interaction
 
@@ -431,16 +508,24 @@ float restore = -12.0f;  // app remembers the pre-mute value
 memcpy(payload, &restore, 4);
 usb_vendor_out(0xD2, payload, 4);
 
-// User enables include_master_volume
-uint8_t include = 1;
-usb_vendor_out(0xD4, &include, 1);
+// User toggles mode to "with preset"
+uint8_t mode = 1;
+usb_vendor_out(0xD4, &mode, 1);
+
+// User clicks "Save as boot default" (mode 0 persistence)
+usb_vendor_out(0xD6, NULL, 0);
+
+// User clicks "Revert to saved"
+float saved;
+usb_vendor_in(0xD7, &saved, 4);
+usb_vendor_out(0xD2, &saved, 4);
 ```
 
 **Important:** The firmware applies the new master volume value immediately (within the next audio callback, typically < 1ms). There is no pending/deferred mechanism for master volume itself -- unlike EQ coefficient updates, master volume is a single float that can be applied atomically. There is no acknowledgment; if the USB transfer completes successfully, the value was accepted.
 
 ### Step 4: Handle preset load events
 
-When the user loads a preset (via `REQ_PRESET_LOAD` / 0x91), the master volume may or may not change depending on the `include_master_volume` flag. After a preset load, re-read the master volume to update the UI:
+When the user loads a preset (via `REQ_PRESET_LOAD` / 0x91), the master volume may or may not change depending on `master_volume_mode`. In mode 0 it is guaranteed not to change; in mode 1 it is replaced by the slot's saved value. After a preset load, re-read the master volume to update the UI:
 
 ```
 GET 0xD3 -> update volume slider / mute state
@@ -461,7 +546,7 @@ If your app uses bulk parameter transfers for configuration backup/restore:
 1. Populate `WireMasterVolume` in the `WireBulkParams` struct.
 2. Set `header.format_version` to the current version (6 or later).
 3. Send the complete struct.
-4. Bulk SET always applies master volume regardless of the `include_master_volume` directory flag.
+4. Bulk SET always applies master volume to the live globals regardless of `master_volume_mode`. It does **not** update the independent storage field — if the user is in mode 0 and expects the pushed value to survive a reboot, follow the bulk SET with `REQ_SAVE_MASTER_VOLUME` (0xD6).
 
 ### Step 6: Mute implementation pattern
 
@@ -507,31 +592,49 @@ All numeric values in the wire protocol are **little-endian**, which is the nati
 
 ## 7. Backward Compatibility
 
+### Directory v1 → v2 migration
+
+Devices running firmware built before the mode-flag refactor have a `PresetDirectory` with `version = 1` (containing `include_master_volume` as a `uint8_t` at the same byte offset now used by `master_volume_mode`). On first boot of new firmware:
+
+1. `dir_load_cache` reads the directory's magic + version from the fixed 12-byte header.
+2. If `version == 1`, the directory is read with a local `PresetDirectory_v1` struct, its v1-sized CRC is validated, and the field values are copied into the new v2 cache:
+   - `master_volume_mode` = old `include_master_volume` (direct 1:1 map — `0` stays `0` meaning "independent" with default 0 dB, `1` stays `1` meaning "with preset")
+   - `master_volume_db` = 0.0 dB (unity)
+   - All other fields (slot names, startup mode, default slot, last active, include_pins, slot occupancy) copied verbatim
+3. The migrated cache is flushed to flash as `version = 2`. The migration is transparent and one-shot.
+4. If the v1 CRC fails to validate, the fresh-directory path runs — identical to a first-ever boot. User-visible directory state (slot names, startup config, slot occupancy) would be lost, but slot contents remain intact.
+
+Audible behavior is unchanged across the upgrade: old `include_master_volume == 0` devices boot at 0 dB (unity) in both the old and new firmware; old `include_master_volume == 1` devices continue to restore master volume from each loaded preset.
+
 ### Old apps with new firmware
 
-Apps that do not know about master volume will never send `REQ_SET_MASTER_VOLUME` (0xD2). The master volume defaults to 0.0 dB (unity) on boot and remains there. The device behaves identically to pre-master-volume firmware. No existing vendor commands are affected.
+Apps that do not know about master volume will never send `REQ_SET_MASTER_VOLUME` (0xD2). Device-side boot behavior continues to be governed by `PresetDirectory.master_volume_db` (mode 0, unity by default) or the loaded preset (mode 1) — same as before on devices that were already in that state.
+
+Apps written for the old `REQ_SET_INCLUDE_MASTER_VOL` / `REQ_GET_INCLUDE_MASTER_VOL` semantics (commands `0xD4` / `0xD5`) continue to work: the command IDs are unchanged, the payloads are still `uint8_t` in `[0, 1]`, and the numeric mapping is 1:1 (value `1` still means "preset restores master volume"; value `0` now means "use independent storage" with a default of 0 dB, which matches the pre-refactor "don't restore on load" boot behavior).
+
+The new commands (`0xD6` `REQ_SAVE_MASTER_VOLUME`, `0xD7` `REQ_GET_SAVED_MASTER_VOLUME`) are additive — old apps that don't issue them are unaffected.
 
 ### New apps with old firmware
 
-Apps that send `REQ_SET_MASTER_VOLUME` (0xD2) to firmware that does not support it will receive a USB STALL response (the vendor command is unrecognized). Apps should handle this gracefully -- for example, by hiding the master volume UI or displaying it as unavailable.
+Apps that send `REQ_SET_MASTER_VOLUME` (0xD2) to firmware that does not support it will receive a USB STALL response. The same is true of the new `0xD6` / `0xD7` commands on firmware that predates them.
 
-Detection strategy: attempt `REQ_GET_MASTER_VOLUME` (0xD3). If the transfer completes successfully, master volume is supported. If it STALLs, it is not.
+Detection strategy:
+- **Master volume feature present?** Attempt `REQ_GET_MASTER_VOLUME` (0xD3). If success, feature is present.
+- **Mode/save API present (vs. the old include-flag API)?** Attempt `REQ_GET_SAVED_MASTER_VOLUME` (0xD7). If it succeeds, the refactored API is in place and the app can use mode 0 independent persistence. If it STALLs, the firmware still speaks the old `include_master_volume` semantics at 0xD4/0xD5 — the app can fall back to treating the byte-6 field of `REQ_PRESET_GET_DIR` as a classic include flag.
 
 ### Old presets
 
 Presets saved with `SLOT_DATA_VERSION` < 12 do not contain a `master_volume_db` field. When loaded:
-- The master volume is left unchanged (not reset to 0 dB), regardless of the `include_master_volume` flag.
-- All other preset fields are restored normally.
+- In mode 1 (per-preset): master volume falls back to `PresetDirectory.master_volume_db` (the independent storage value). Reasonable default — there's nothing to restore from the slot.
+- In mode 0 (independent): master volume is not touched by the slot data anyway.
 
 ### Old bulk transfer payloads
 
-Bulk SET payloads with `format_version` < 6 do not contain the `WireMasterVolume` section. When received:
-- The master volume is set to 0.0 dB (unity).
-- This is a safe default: full output, no attenuation, matching pre-master-volume behavior.
+Bulk SET payloads with `format_version` < 6 do not contain the `WireMasterVolume` section. When received, the master volume is set to 0.0 dB (unity) — unchanged from pre-refactor behavior.
 
 ### Preset directory size
 
-The directory response grew from 6 to 7 bytes. Apps requesting the old 6-byte size continue to work because USB control transfers truncate to `wLength`. Apps that want the new byte must request `wLength >= 7`.
+The directory response is still 7 bytes. Apps requesting the old 6-byte size continue to work because USB control transfers truncate to `wLength`. Byte [6]'s meaning has been redefined (from `include_master_volume` to `master_volume_mode`), but the numeric range and 1:1 behavioral mapping make this transparent.
 
 ---
 
@@ -560,9 +663,11 @@ Effectively zero. The master volume adds a single float multiply to the per-bloc
 ### BSS (RAM) impact
 
 Negligible. The master volume adds:
-- 4 bytes for `master_volume_db` (float)
-- 4 bytes for `master_volume_linear` (precomputed float multiplier)
-- 1 byte for `include_master_volume` in the directory cache
+- 4 bytes for `master_volume_db` (float) — live global
+- 4 bytes for `master_volume_linear` (precomputed float multiplier) — live global
+- 4 bytes for `master_volume_q15` (precomputed Q15 multiplier, RP2040 path) — live global
+- 1 byte for `master_volume_mode` in the directory cache
+- 4 bytes for `master_volume_db` in the directory cache (independent storage)
 
 ### Sample rate handling
 

--- a/Documentation/Features/master_volume_spec.md
+++ b/Documentation/Features/master_volume_spec.md
@@ -233,25 +233,25 @@ Payload: [0x01]
 
 | Field | Value |
 |-------|-------|
-| **Direction** | Host -> Device (OUT) |
+| **Direction** | Device -> Host (IN) |
 | **bRequest** | `0xD6` |
 | **wValue** | Unused (0) |
 | **wIndex** | Unused (0) |
-| **wLength** | 0 |
-| **Payload** | None |
+| **wLength** | 1 |
+| **Response** | 1 byte: status code (`PRESET_OK` = 0 on acceptance) |
 
-Copies the current live `master_volume_db` into the directory's independent storage field and flushes the directory sector to flash. This is the command that makes a chosen master volume survive a power cycle in mode 0.
+Action-style command: copies the current live `master_volume_db` into the directory's independent storage field and flushes the directory sector to flash. This is the command that makes a chosen master volume survive a power cycle in mode 0. Follows the same request shape as `REQ_FACTORY_RESET` — an IN control transfer with a 1-byte status response, no OUT payload.
 
 **Firmware behavior:**
 1. Sets a pending flag for a deferred flash write on the next main loop iteration.
-2. Main loop captures the then-current live `master_volume_db` value and writes it to the directory.
-3. No value is returned; the transfer completes once the command is accepted.
+2. Returns `PRESET_OK` (0) immediately — the status confirms acceptance, not completion of the flash write. The subsequent main-loop dispatch captures the then-current live `master_volume_db` value and writes it to the directory.
 
 **Accepted in both modes.** In mode 1 the stored value is dormant until the user switches to mode 0, so the app can issue this command regardless of mode without a pre-check. No error is surfaced for a "wrong mode" — the write simply becomes inert.
 
 **Example:** Persist the currently active master volume:
 ```
-bRequest = 0xD6, wValue = 0x0000, wIndex = 0x0000, wLength = 0
+bmRequestType = 0xC0, bRequest = 0xD6, wValue = 0x0000, wIndex = 0x0000, wLength = 1
+Response: [0x00]   (PRESET_OK)
 ```
 
 ### 3.6 REQ_GET_SAVED_MASTER_VOLUME (0xD7)
@@ -512,8 +512,11 @@ usb_vendor_out(0xD2, payload, 4);
 uint8_t mode = 1;
 usb_vendor_out(0xD4, &mode, 1);
 
-// User clicks "Save as boot default" (mode 0 persistence)
-usb_vendor_out(0xD6, NULL, 0);
+// User clicks "Save as boot default" (mode 0 persistence).
+// REQ_SAVE_MASTER_VOLUME is an IN-shaped action command like REQ_FACTORY_RESET:
+// host issues a 1-byte IN transfer, device responds with status (0 = accepted).
+uint8_t status;
+usb_vendor_in(0xD6, &status, 1);
 
 // User clicks "Revert to saved"
 float saved;

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 It is my hope that the RP2040 and RP2350 will garner a reputation as the "swiss army knife of audio for less than a cup of coffee".
 
+Feel free to join the [official Discord server](https://discord.gg/RCyqxAQ5xS) for development updates, discussion or to request assistance!
+
 ---
 
 ## Table of Contents

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ It is my hope that the RP2040 and RP2350 will garner a reputation as the "swiss 
   - [Parametric Equalization](#parametric-equalization)
   - [Loudness Compensation](#loudness-compensation)
   - [Headphone Crossfeed](#headphone-crossfeed)
+  - [Volume Leveller](#volume-leveller)
+  - [Per-Channel Preamp](#per-channel-preamp)
+  - [Master Volume](#master-volume)
+  - [I2S Output](#i2s-output)
   - [Subwoofer PDM Output](#subwoofer-pdm-output)
 - [User Presets](#user-presets)
 - [Developer Reference](#developer-reference)
@@ -26,24 +30,30 @@ It is my hope that the RP2040 and RP2350 will garner a reputation as the "swiss 
   - [System Telemetry](#reqgetstatus-0x50---system-telemetry)
   - [Data Structures](#data-structures)
 - [Building from Source](#building-from-source)
+- [Detailed Specifications](#detailed-specifications)
 - [License](#license)
 
 ---
 
 ## Key Capabilities
 
-*   **USB Audio Interface:** Plug-and-play under macOS, Windows, Linux, and iOS. Supports 16-bit and 24-bit PCM input at 44.1/48 kHz.
-*   **24-bit S/PDIF Outputs:** Up to four independent stereo S/PDIF outputs (8 channels on RP2350, 4 channels on RP2040) with 24-bit output for multi-way active speaker systems, enabling use of any standard DAC.
+*   **USB Audio Interface:** Plug-and-play under macOS, Windows, Linux, and iOS. Supports 16-bit and 24-bit PCM input at 44.1, 48, and 96 kHz.
+*   **24-bit S/PDIF or I2S Outputs:** Up to four independent stereo output slots (8 channels on RP2350, 4 channels on RP2040). Each slot can be switched at runtime between S/PDIF and I2S, enabling direct connection to any standard DAC. I2S slots share a common BCK/LRCLK and can optionally produce a 128×/256× master clock.
+*   **Per-Channel Preamp:** Independent gain control for each USB input channel (L/R), applied as PASS 1 of the DSP pipeline before any other processing.
 *   **Matrix Mixer:** Route either or both USB input channels to any output with independent gain and phase invert per crosspoint. 2x9 on RP2350, 2x5 on RP2040.
 *   **Parametric Equalization:** Up to 10 PEQ bands per channel with 6 filter types. 110 total filter bands on RP2350, 70 on RP2040. RP2350 uses a hybrid SVF/biquad architecture for superior low-frequency accuracy.
+*   **Volume Leveller:** RMS-based, stereo-linked, soft-knee upward compressor that lifts quieter content toward a target level without ever amplifying loud passages. Optional 10 ms lookahead, configurable speed and max-gain ceiling, with a -6 dBFS gain-reduction safety limiter.
 *   **Loudness Compensation:** Volume-dependent EQ based on the ISO 226:2003 equal-loudness contour standard. Automatically boosts bass and treble at low listening levels to maintain perceived tonal balance.
 *   **Headphone Crossfeed:** BS2B-based crossfeed with interaural time delay (ITD) reduces unnatural stereo separation for headphone listening. Three classic presets plus fully custom parameters.
+*   **Master Volume:** Device-side output ceiling (-128 to 0 dB, with a true-mute sentinel) applied at the very end of the signal chain, independent of USB host volume and DSP processing. Two persistence modes: stored independently of presets (default — survives reboots, unaffected by preset switching) or saved/restored as part of each preset.
 *   **Per-Output Gain & Mute:** Independent gain and mute controls for each output channel.
-*   **Time Alignment:** Per-output delay (up to 85ms) for speaker/subwoofer alignment with automatic latency compensation between S/PDIF and PDM output paths.
+*   **Time Alignment:** Per-output delay (up to 85ms) for speaker/subwoofer alignment with automatic latency compensation between S/PDIF/I2S and PDM output paths.
 *   **Subwoofer Output:** Dedicated mono PDM output channel with a high-performance 2nd-order delta-sigma modulator, enabling direct subwoofer output without the need for a second DAC.
 *   **Dual-Core DSP:** EQ processing is split across both cores on both platforms for maximum throughput when multiple outputs are active.
-*   **Configurable Output Pins:** All output GPIO pins can be reassigned at runtime to suit custom PCB layouts, no reflashing required.
+*   **Configurable Output Pins:** All output GPIO pins (including I2S BCK/MCK) can be reassigned at runtime to suit custom PCB layouts, no reflashing required.
 *   **10-Slot Preset System:** Save, load, and manage up to 10 complete DSP configurations with user-defined names. Includes per-channel naming, configurable startup slot, and bulk parameter transfer for fast state synchronization.
+*   **Diagnostics:** Per-channel peak/clip metering, USB PHY error counters (CRC, bit-stuff, timeout, overflow, sequence), buffer fill statistics, S/PDIF DMA starvation counters per output slot, and CPU load reporting per core.
+*   **Firmware Update via USB:** A vendor command reboots the device into the UF2 bootloader, allowing the host app to push new firmware without a physical BOOTSEL press.
 
 ---
 
@@ -51,12 +61,14 @@ It is my hope that the RP2040 and RP2350 will garner a reputation as the "swiss 
 
 | Feature | RP2040 (Pico) | RP2350 (Pico 2) |
 |---------|---------------|-----------------|
-| **Clock Speed** | 288 MHz (OC) | 288 MHz |
+| **System Clock** | 307.2 MHz (overclock) | 307.2 MHz |
+| **Core Voltage** | 1.15 V | 1.15 V |
+| **Sample Rates** | 44.1 / 48 / 96 kHz | 44.1 / 48 / 96 kHz |
 | **Audio Processing** | Q28 Fixed-Point | Single-Precision Float |
 | **EQ Bands** | 10 per channel (70 total) | 10 per channel (110 total) |
-| **Total Channels** | 7 (2 master + 4 S/PDIF + 1 PDM) | 11 (2 master + 8 S/PDIF + 1 PDM) |
-| **S/PDIF Outputs** | 2 stereo pairs (4 channels) | 4 stereo pairs (8 channels) |
-| **S/PDIF Bit Depth** | 24-bit | 24-bit |
+| **Total Channels** | 7 (2 master + 4 S/PDIF·I2S + 1 PDM) | 11 (2 master + 8 S/PDIF·I2S + 1 PDM) |
+| **Output Slots** | 2 stereo (each S/PDIF or I2S) | 4 stereo (each S/PDIF or I2S) |
+| **Output Bit Depth** | 24-bit | 24-bit |
 | **PDM Output** | 1 (subwoofer) | 1 (subwoofer) |
 | **Max Delay** | 85ms per output | 85ms per output |
 | **Math Engine** | Hand-optimized ARM Assembly | Hardware FPU (hybrid SVF/biquad EQ) |
@@ -64,7 +76,7 @@ It is my hope that the RP2040 and RP2350 will garner a reputation as the "swiss 
 | **User Presets** | 10 slots | 10 slots |
 | **Status** | Production | Production |
 
-Both platforms are fully tested and production-ready. The RP2350 offers significantly more processing headroom thanks to its hardware floating-point unit, enabling more output channels and a hybrid SVF/biquad filter architecture for improved low-frequency accuracy.
+Both platforms are fully tested and production-ready. The RP2040 reaches 307.2 MHz with a slight voltage bump; the RP2350 hits the same frequency at the same voltage. Clock is fixed (no rate-dependent switching), and PIO dividers are integer at every supported sample rate. The RP2350 offers significantly more processing headroom thanks to its hardware floating-point unit, enabling more output channels and a hybrid SVF/biquad filter architecture for improved low-frequency accuracy.
 
 ---
 
@@ -75,58 +87,69 @@ DSPi processes audio in a linear, low-latency pipeline:
 **RP2350 (11 channels, 9 outputs):**
 
 ```
-USB Input (16/24-bit PCM Stereo)
+USB Input (16/24-bit PCM Stereo, 44.1 / 48 / 96 kHz)
     |
-Preamp (global gain adjustment)
+PASS 1: Per-Channel Preamp (independent L/R gain) + USB Volume
     |
-Loudness Compensation (volume-dependent EQ, optional)
+PASS 2: Master EQ (10 bands per channel, Left/Right)
     |
-Master EQ (10 bands per channel, Left/Right)
+PASS 2.5: Volume Leveller (RMS upward compression, optional)
     |
-Headphone Crossfeed (BS2B + ITD, optional)
+PASS 3: Headphone Crossfeed (BS2B + ITD, optional) + Master Peak Metering
     |
-Matrix Mixer (2 inputs x 9 outputs, per-crosspoint gain & phase)
+        Loudness Compensation (volume-dependent EQ, optional)
     |
-    +-- Out 1-2 --> Output EQ --> Gain/Mute --> Delay --> S/PDIF 1 (GPIO 6)
-    +-- Out 3-4 --> Output EQ --> Gain/Mute --> Delay --> S/PDIF 2 (GPIO 7)
-    +-- Out 5-6 --> Output EQ --> Gain/Mute --> Delay --> S/PDIF 3 (GPIO 8)
-    +-- Out 7-8 --> Output EQ --> Gain/Mute --> Delay --> S/PDIF 4 (GPIO 9)
-    +-- Out 9   --> Output EQ --> Gain/Mute --> Delay --> PDM Sub  (GPIO 10)
+PASS 4: Matrix Mixer (2 inputs x 9 outputs, per-crosspoint gain & phase)
+    |
+PASS 5: Per-Output EQ -> Gain/Mute -> Delay -> Output Gain × Master Volume
+    |
+    +-- Out 1-2 --> S/PDIF or I2S slot 0 (data: GPIO 6 default)
+    +-- Out 3-4 --> S/PDIF or I2S slot 1 (data: GPIO 7 default)
+    +-- Out 5-6 --> S/PDIF or I2S slot 2 (data: GPIO 8 default)
+    +-- Out 7-8 --> S/PDIF or I2S slot 3 (data: GPIO 9 default)
+    +-- Out 9   --> PDM Sub               (data: GPIO 10 default)
+                  (I2S BCK/LRCLK shared on GPIO 14/15 default; optional MCK on GPIO 13 default)
 ```
 
 **RP2040 (7 channels, 5 outputs):**
 
 ```
-USB Input (16/24-bit PCM Stereo)
+USB Input (16/24-bit PCM Stereo, 44.1 / 48 / 96 kHz)
     |
-Preamp (global gain adjustment)
+PASS 1: Per-Channel Preamp + USB Volume
     |
-Loudness Compensation (volume-dependent EQ, optional)
+PASS 2: Master EQ (10 bands per channel, Left/Right)
     |
-Master EQ (10 bands per channel, Left/Right)
+PASS 2.5: Volume Leveller (RMS upward compression, optional)
     |
-Headphone Crossfeed (BS2B + ITD, optional)
+PASS 3: Headphone Crossfeed (BS2B + ITD, optional) + Master Peak Metering
     |
-Matrix Mixer (2 inputs x 5 outputs, per-crosspoint gain & phase)
+        Loudness Compensation (volume-dependent EQ, optional)
     |
-    +-- Out 1-2 --> Output EQ --> Gain/Mute --> Delay --> S/PDIF 1 (GPIO 6)
-    +-- Out 3-4 --> Output EQ --> Gain/Mute --> Delay --> S/PDIF 2 (GPIO 7)
-    +-- Out 5   --> Output EQ --> Gain/Mute --> Delay --> PDM Sub  (GPIO 10)
+PASS 4: Matrix Mixer (2 inputs x 5 outputs, per-crosspoint gain & phase)
+    |
+PASS 5: Per-Output EQ -> Gain/Mute -> Delay -> Output Gain × Master Volume
+    |
+    +-- Out 1-2 --> S/PDIF or I2S slot 0 (data: GPIO 6 default)
+    +-- Out 3-4 --> S/PDIF or I2S slot 1 (data: GPIO 7 default)
+    +-- Out 5   --> PDM Sub               (data: GPIO 10 default)
+                  (I2S BCK/LRCLK shared on GPIO 14/15 default; optional MCK on GPIO 13 default)
 ```
 
 ### Signal Chain Details
 
-1.  **Input (USB):** 16-bit or 24-bit PCM stereo audio from your host device (selectable via USB alt setting).
-2.  **Preamp:** Global gain adjustment applied to both channels.
-3.  **Loudness Compensation:** Optional ISO 226:2003 equal-loudness EQ that adapts to the current volume level. At low volumes, bass and treble are boosted to compensate for the ear's reduced sensitivity. Configurable reference SPL and intensity.
-4.  **Master EQ:** Up to 10 bands of parametric EQ per channel (Left/Right). Supports peaking, low shelf, high shelf, low pass, and high pass filter types.
-5.  **Headphone Crossfeed:** Optional BS2B crossfeed that mixes a filtered, delayed portion of each channel into the opposite channel. Uses a complementary filter design with interaural time delay (ITD) via an all-pass filter. Three presets (Default, Chu Moy, Jan Meier) plus custom frequency and feed level. ITD can be independently toggled.
-6.  **Matrix Mixer:** Routes the two USB input channels (Left/Right) to all output channels. Each crosspoint has independent enable, gain (-inf to +12dB), and phase invert. Outputs can be individually enabled/disabled to save CPU. RP2350 has a 2x9 matrix (9 outputs), RP2040 has a 2x5 matrix (5 outputs).
-7.  **Output EQ:** Independent 10-band EQ per output channel on both platforms. Ideal for crossover filters and per-driver correction. On RP2350, filters below Fs/7.5 use SVF topology for superior low-frequency accuracy; higher frequencies use traditional biquad.
-8.  **Per-Output Gain & Mute:** Independent gain (-inf to +12dB) and mute for each output channel.
-9.  **Master Volume:** USB audio class volume control (-91 to 0 dB).
-10. **Time Alignment:** Per-output delay for speaker alignment, up to 85ms (4096 samples at 48kHz) on both platforms. Automatic latency compensation between S/PDIF and PDM output paths.
-11. **S/PDIF Outputs:** 24-bit digital audio. RP2350: four stereo pairs on GPIO 6-9. RP2040: two stereo pairs on GPIO 6-7. Plus one PDM mono output (subwoofer) on GPIO 10.
+1.  **Input (USB):** 16-bit or 24-bit PCM stereo audio at 44.1, 48, or 96 kHz. Bit depth is selected via USB alt setting; sample rate via the USB Audio Class rate-set request.
+2.  **Per-Channel Preamp (PASS 1):** Independent gain control for the USB Left and Right input channels in dB. Applied at the very start of the DSP chain so its setting affects all downstream processing.
+3.  **Master EQ (PASS 2):** Up to 10 bands of parametric EQ per channel (Left/Right). Supports peaking, low shelf, high shelf, low pass, and high pass filter types.
+4.  **Volume Leveller (PASS 2.5):** Optional feedforward, stereo-linked, single-band RMS compressor with soft-knee upward compression — quieter content is boosted toward a target level while content above the threshold passes through untouched. Configurable speed, max-gain ceiling, and noise gate. Optional 10 ms lookahead. A -6 dBFS gain-reduction safety limiter prevents output overshoots.
+5.  **Headphone Crossfeed (PASS 3):** Optional BS2B crossfeed that mixes a filtered, delayed portion of each channel into the opposite channel. Uses a complementary filter design with interaural time delay (ITD) via an all-pass filter. Three presets (Default, Chu Moy, Jan Meier) plus custom frequency and feed level. ITD can be independently toggled. Master peak metering taps into this stage.
+6.  **Loudness Compensation:** Optional ISO 226:2003 equal-loudness EQ that adapts to the current volume level. At low volumes, bass and treble are boosted to compensate for the ear's reduced sensitivity. Configurable reference SPL and intensity. Driven by the USB host volume position so it remains correct regardless of master-volume attenuation downstream.
+7.  **Matrix Mixer (PASS 4):** Routes the two USB input channels (Left/Right) to all output channels. Each crosspoint has independent enable, gain (-inf to +12 dB), and phase invert. Outputs can be individually enabled/disabled to save CPU. RP2350 has a 2x9 matrix (9 outputs), RP2040 has a 2x5 matrix (5 outputs).
+8.  **Output EQ (PASS 5):** Independent 10-band EQ per output channel on both platforms. Ideal for crossover filters and per-driver correction. On RP2350, filters below Fs/7.5 use SVF topology for superior low-frequency accuracy; higher frequencies use traditional biquad.
+9.  **Per-Output Gain & Mute:** Independent gain (-inf to +12 dB) and mute for each output channel.
+10. **Time Alignment:** Per-output delay for speaker alignment, up to 85 ms (4096 samples at 48 kHz). Automatic latency compensation between S/PDIF/I2S and PDM output paths.
+11. **Master Volume:** Device-side output ceiling, -128 to 0 dB with a true-mute sentinel at -128. Folded into the per-output multiplier at PASS 5 so it's effectively free CPU-wise. Independent of the USB host volume — the two multiply together. Does not affect loudness-compensation behavior.
+12. **Outputs:** Each numbered slot is configurable as either 24-bit S/PDIF or 24-bit I2S (left-justified, MSB-first). I2S slots share a common BCK/LRCLK clock pair (LRCLK is always BCK + 1 due to a PIO side-set constraint). An optional master clock (MCK) at 128× or 256× Fs can be routed to a separate GPIO. PDM subwoofer is always on its own dedicated output and pin.
 
 ---
 
@@ -142,33 +165,39 @@ Matrix Mixer (2 inputs x 5 outputs, per-crosspoint gain & phase)
 
 ### Wiring Guide
 
-**RP2350 (Pico 2) — 5 output pins:**
+**RP2350 (Pico 2) — up to 8 output pins:**
 
 | Function | Pin | Connection |
 | :--- | :--- | :--- |
-| **S/PDIF Output 1** (Out 1-2) | `GPIO 6` (default) | DAC or receiver for main L/R or multi-way pair 1 |
-| **S/PDIF Output 2** (Out 3-4) | `GPIO 7` (default) | DAC or receiver for multi-way pair 2 |
-| **S/PDIF Output 3** (Out 5-6) | `GPIO 8` (default) | DAC or receiver for multi-way pair 3 |
-| **S/PDIF Output 4** (Out 7-8) | `GPIO 9` (default) | DAC or receiver for multi-way pair 4 |
+| **Output Slot 0** (Out 1-2) | `GPIO 6` (default) | S/PDIF or I2S data for main L/R or multi-way pair 1 |
+| **Output Slot 1** (Out 3-4) | `GPIO 7` (default) | S/PDIF or I2S data for multi-way pair 2 |
+| **Output Slot 2** (Out 5-6) | `GPIO 8` (default) | S/PDIF or I2S data for multi-way pair 3 |
+| **Output Slot 3** (Out 7-8) | `GPIO 9` (default) | S/PDIF or I2S data for multi-way pair 4 |
 | **Subwoofer Out** (PDM, Out 9) | `GPIO 10` (default) | Active subwoofer or PDM-to-analog filter |
+| **I2S BCK** (shared, I2S only) | `GPIO 14` (default) | Bit clock for any slot configured as I2S |
+| **I2S LRCLK** (I2S only) | `GPIO 15` (BCK + 1, fixed) | Word/frame clock; always BCK + 1 |
+| **I2S MCK** (optional) | `GPIO 13` (default) | 128× or 256× Fs master clock when MCK is enabled |
 | **USB** | `Micro-USB` | Host device (PC/Mac/Mobile Device) |
 
-**RP2040 (Pico) — 3 output pins:**
+**RP2040 (Pico) — up to 6 output pins:**
 
 | Function | Pin | Connection |
 | :--- | :--- | :--- |
-| **S/PDIF Output 1** (Out 1-2) | `GPIO 6` (default) | DAC or receiver for main L/R or stereo pair 1 |
-| **S/PDIF Output 2** (Out 3-4) | `GPIO 7` (default) | DAC or receiver for stereo pair 2 |
+| **Output Slot 0** (Out 1-2) | `GPIO 6` (default) | S/PDIF or I2S data for main L/R or stereo pair 1 |
+| **Output Slot 1** (Out 3-4) | `GPIO 7` (default) | S/PDIF or I2S data for stereo pair 2 |
 | **Subwoofer Out** (PDM, Out 5) | `GPIO 10` (default) | Active subwoofer or PDM-to-analog filter |
+| **I2S BCK** (shared, I2S only) | `GPIO 14` (default) | Bit clock for any slot configured as I2S |
+| **I2S LRCLK** (I2S only) | `GPIO 15` (BCK + 1, fixed) | Word/frame clock; always BCK + 1 |
+| **I2S MCK** (optional) | `GPIO 13` (default) | 128× or 256× Fs master clock when MCK is enabled |
 | **USB** | `Micro-USB` | Host device (PC/Mac/Mobile Device) |
 
-> **Note:** S/PDIF output requires either a Toshiba TX179 optical transmitter or a simple resistor divider. PDM output is a 1-bit logic signal that requires a resistor and capacitor to form a low-pass filter for conversion to analog audio.
+> **Notes:** S/PDIF output requires either a Toshiba TX179 optical transmitter or a simple resistor divider. I2S output is a standard 24-bit-in-32-bit left-justified frame — wires straight into most I2S DACs. PDM output is a 1-bit logic signal that requires a resistor and capacitor to form a low-pass filter for conversion to analog audio.
 
 ### Custom Pin Assignments
 
-The default pin assignments above work out of the box, but all output pins can be reassigned at runtime through the DSPi Console application — no reflashing required. This is useful when designing custom PCBs or adapting to boards where the default GPIOs are inconvenient.
+All default pin assignments above work out of the box, but every output pin — including I2S BCK and MCK — can be reassigned at runtime through the DSPi Console application. No reflashing required. This is useful when designing custom PCBs or adapting to boards where the default GPIOs are inconvenient.
 
-Pin assignments are saved to flash and restored automatically at boot. A few GPIOs are reserved and unavailable for output use: GPIO 12 (UART TX) and GPIOs 23-25 (power control and LED).
+Pin assignments are saved to flash and restored automatically at boot. A few GPIOs are reserved and unavailable for output use: GPIO 12 (UART TX) and GPIOs 23-25 (power control and LED). LRCLK is always pinned to BCK + 1 due to a PIO side-set constraint.
 
 <img src="Images/toslink.jpg" alt="Alt text" width="49%">  <img src="Images/spdif_converter.jpg" alt="Alt text" width="49%">
 
@@ -284,6 +313,47 @@ Implements Bauer Stereophonic-to-Binaural (BS2B) crossfeed with a complementary 
 | Jan Meier | 650 Hz | 9.5 dB | Subtle, natural |
 | Custom | 500-2000 Hz | 0-15 dB | User-defined |
 
+### Volume Leveller
+
+A feedforward, stereo-linked, single-band RMS dynamic range compressor that maintains consistent perceived volume across content with varying loudness.
+
+*   **Upward compression:** Boosts content below the threshold while leaving content above the threshold completely untouched. No makeup gain needed.
+*   **RMS-based detection:** Tracks root-mean-square envelope, which correlates with perceived loudness better than peak detection.
+*   **Soft-knee:** Gradual transition between full boost and unity gain for transparent, artifact-free behavior.
+*   **Stereo-linked:** The louder of the two channels determines gain for both, preserving the stereo image.
+*   **Gain-reduction safety limiter:** -6 dBFS ceiling enforced via gain reduction (instant attack, 100 ms release) rather than hard clipping. Rarely engages since loud content passes through at unity.
+*   **Optional 10 ms lookahead** for smoother transitions.
+*   **Configurable:** speed (attack/release), max-gain ceiling (cap on how much quiet content can be lifted), and gate threshold (below which the leveller stops boosting to avoid amplifying silence/noise).
+
+The leveller sits at PASS 2.5 — after Master EQ, before crossfeed. Independent of Loudness Compensation; both can be enabled together without conflict.
+
+### Per-Channel Preamp
+
+Each USB input channel (Left and Right) has an independent preamp gain in dB, applied at PASS 1 before any other processing. Useful for trimming channel imbalance, attenuating hot inputs ahead of EQ, or matching levels across sources. A legacy single-value command remains for backward compatibility (sets both channels to the same value).
+
+### Master Volume
+
+A device-side output ceiling applied at the very end of the signal chain, independent of USB host volume.
+
+*   **Range:** -128 to 0 dB. -128 is a sentinel for true silence (mute).
+*   **Independent of USB host volume:** the two multiply together. The host slider operates within whatever range master volume permits.
+*   **Independent of DSP processing:** loudness compensation, EQ, leveller, and crossfeed are all driven by the raw USB volume, not the master volume — their behavior is unchanged regardless of the master setting.
+*   **Two persistence modes** (selectable at runtime, persists across reboots):
+    *   **Mode 0 — Independent (default).** Master volume is a stand-alone device setting. The app calls a save command to capture the current value into the directory; that value is applied at every subsequent boot. Preset save/load do not touch master volume — switching presets never moves the volume.
+    *   **Mode 1 — With preset.** Master volume is part of each preset. Saved with the preset, restored on preset load, like any other DSP parameter. Useful when different presets target speaker setups with different sensitivity / maximum-output requirements.
+*   **Default at first boot:** -20 dB (configurable via `MASTER_VOL_DEFAULT_DB` in firmware).
+
+### I2S Output
+
+Each output slot can be switched at runtime between S/PDIF (default) and I2S, independently per slot. A single device can drive a mix — e.g., slot 0 as I2S into a DAC chip, slot 1 as S/PDIF over Toslink to an external receiver, all from the same audio pipeline.
+
+*   **I2S format:** 24-bit data, left-justified, MSB-first, 32-bit frames. Drop-in to most standard I2S DACs (PCM5102, ES9038Q2M, etc.).
+*   **Shared clocks:** All I2S slots share a single BCK/LRCLK pair. LRCLK is always BCK + 1 (PIO side-set hardware constraint).
+*   **Optional MCK:** When enabled, a 128× or 256× Fs master clock is generated on a configurable GPIO. Required by some DACs that don't have an internal PLL. At 96 kHz, only 128× is selectable due to PIO clock-divisor limits.
+*   **Sample-aligned start:** I2S slots can be brought up together so multiple DACs stay phase-locked.
+
+The DSP pipeline is identical for both output types — only the final encoding differs (BMC/NRZI for S/PDIF vs. raw left-justified PCM for I2S).
+
 ### Subwoofer PDM Output
 
 The subwoofer output uses a high-performance software-defined delta-sigma modulator running on Core 1.
@@ -301,13 +371,15 @@ The objective was to use as much of Core 1 as necessary to produce an output tha
 
 DSPi includes a 10-slot preset system that stores complete DSP configurations in flash. A preset is always active — there is no "no preset" state.
 
-*   **10 Preset Slots:** Each slot stores the full DSP state: EQ bands, preamp, delays, loudness, crossfeed, matrix mixer, output gains/mutes, pin assignments, and per-channel names.
+*   **10 Preset Slots:** Each slot stores the full DSP state: per-channel preamp, EQ bands, delays, loudness, leveller, crossfeed, matrix mixer, output gains/mutes, output type (S/PDIF or I2S), I2S clock configuration, pin assignments, master volume (used in Mode 1), and per-channel names.
 *   **Per-Channel Names:** Each channel can be given a user-defined name (up to 31 characters) that is stored with the preset.
 *   **Startup Configuration:** Choose which preset loads on boot — either a specific default slot or whichever slot was last active.
-*   **Pin Config Inclusion:** Optionally include or exclude GPIO pin assignments when saving/loading presets (default: exclude).
-*   **Preset-Switch Mute:** Audio output is briefly muted (~5ms) during preset transitions to prevent audible glitches.
+*   **Pin Config Inclusion:** Optionally include or exclude GPIO pin assignments when saving/loading presets (default: include — pin layout travels with the preset).
+*   **Master Volume Mode:** Selects whether master volume is part of each preset (Mode 1) or stored independently in the preset directory (Mode 0, default). See [Master Volume](#master-volume).
+*   **Preset-Switch Mute:** Audio output is briefly muted (~10 ms) during preset transitions to prevent audible glitches.
 *   **Legacy Commands:** The original save/load/reset commands (0x51-0x53) redirect through the preset system, operating on the currently active slot.
-*   **Bulk Parameter Transfer:** The complete DSP state can be read or written in a single USB control transfer (~2.8 KB) for fast synchronization with host applications.
+*   **Bulk Parameter Transfer:** The complete DSP state can be read or written in a single USB control transfer (~2.9 KB) for fast synchronization with host applications.
+*   **Auto-Migration:** Older preset directories are upgraded transparently on first boot of new firmware — slot names, startup config, and other persisted state are preserved.
 
 ---
 
@@ -329,14 +401,16 @@ DSPi includes a 10-slot preset system that stores complete DSP configurations in
 
 ### Performance Tuning
 
-The firmware dynamically adjusts clock speed based on sample rate to maintain optimal PIO divider ratios for S/PDIF timing accuracy:
+Both platforms run at a fixed 307.2 MHz system clock (VCO 1536 MHz / 5 / 1) so PIO dividers stay integer at every supported sample rate, eliminating sample-rate-dependent clock switching glitches.
 
-| Platform | 44.1 kHz Mode | 48 kHz Mode | Core Voltage |
-|----------|---------------|-------------|--------------|
-| **RP2040** | 264.6 MHz | 288 MHz | 1.20V (overclock) |
-| **RP2350** | 264.6 MHz | 288 MHz | 1.10V (nominal) |
+| Platform | System Clock | Core Voltage |
+|----------|--------------|--------------|
+| **RP2040** | 307.2 MHz (overclock) | 1.15 V |
+| **RP2350** | 307.2 MHz | 1.15 V |
 
-The RP2040 requires a slight voltage bump to reliably reach 288 MHz, while the RP2350 achieves this at its default voltage. Clock switching occurs automatically during sample rate changes with proper sequencing (voltage adjustment before frequency increase).
+The RP2040 reaches 307.2 MHz with a slight voltage bump above the 1.10 V nominal; the RP2350 is comfortable at the same voltage at this clock. The voltage step is applied before the frequency change. Sample rate changes do not retune the system clock, only the PIO dividers, so transitions between 44.1 / 48 / 96 kHz are seamless.
+
+Flash access is also tuned: `PICO_FLASH_SPI_CLKDIV` is set to 6 to keep XIP and erase/program operations safely below the W25Q080's 104–133 MHz spec at this clock. On the RP2350, runtime QMI register management is handled by `firmware/DSPi/flash_clkdiv.c` since the bootrom does not honor the boot2 setting on that platform.
 
 ### USB Control Protocol
 
@@ -408,8 +482,43 @@ Configuration is performed via **Interface 2** (Vendor Interface) using Control 
 | `0x9A` | `REQ_PRESET_GET_ACTIVE` | IN | 1 byte | Get currently active preset slot index |
 | `0x9B` | `REQ_SET_CHANNEL_NAME` | OUT | 32 bytes | Set channel name (wValue=channel) |
 | `0x9C` | `REQ_GET_CHANNEL_NAME` | IN | 32 bytes | Get channel name (wValue=channel) |
-| `0xA0` | `REQ_GET_ALL_PARAMS` | IN | ~2832 bytes | Bulk read entire DSP state (multi-packet) |
-| `0xA1` | `REQ_SET_ALL_PARAMS` | OUT | ~2832 bytes | Bulk write entire DSP state (multi-packet) |
+| `0xA0` | `REQ_GET_ALL_PARAMS` | IN | ~2896 bytes | Bulk read entire DSP state (multi-packet) |
+| `0xA1` | `REQ_SET_ALL_PARAMS` | OUT | ~2896 bytes | Bulk write entire DSP state (multi-packet) |
+| `0xB0` | `REQ_GET_BUFFER_STATS` | IN | variable | Read buffer fill statistics |
+| `0xB1` | `REQ_RESET_BUFFER_STATS` | IN | 1 byte | Reset buffer statistics counters |
+| `0xB2` | `REQ_GET_USB_ERROR_STATS` | IN | 24 bytes | Read USB PHY error counters (CRC/bit-stuff/timeout/overflow/seq) |
+| `0xB3` | `REQ_RESET_USB_ERROR_STATS` | IN | 1 byte | Reset USB PHY error counters |
+| `0xB4` | `REQ_SET_LEVELLER_ENABLE` | OUT | 1 byte | Enable/disable Volume Leveller |
+| `0xB5` | `REQ_GET_LEVELLER_ENABLE` | IN | 1 byte | Get leveller enable state |
+| `0xB6` | `REQ_SET_LEVELLER_AMOUNT` | OUT | 4 bytes | Set leveller target/amount (float) |
+| `0xB7` | `REQ_GET_LEVELLER_AMOUNT` | IN | 4 bytes | Get leveller amount |
+| `0xB8` | `REQ_SET_LEVELLER_SPEED` | OUT | 1 byte | Set leveller attack/release speed |
+| `0xB9` | `REQ_GET_LEVELLER_SPEED` | IN | 1 byte | Get leveller speed |
+| `0xBA` | `REQ_SET_LEVELLER_MAX_GAIN` | OUT | 4 bytes | Set max upward gain (float dB) |
+| `0xBB` | `REQ_GET_LEVELLER_MAX_GAIN` | IN | 4 bytes | Get max upward gain |
+| `0xBC` | `REQ_SET_LEVELLER_LOOKAHEAD` | OUT | 1 byte | Enable/disable 10 ms lookahead |
+| `0xBD` | `REQ_GET_LEVELLER_LOOKAHEAD` | IN | 1 byte | Get lookahead state |
+| `0xBE` | `REQ_SET_LEVELLER_GATE` | OUT | 4 bytes | Set noise-gate threshold (float dB) |
+| `0xBF` | `REQ_GET_LEVELLER_GATE` | IN | 4 bytes | Get noise-gate threshold |
+| `0xC0` | `REQ_SET_OUTPUT_TYPE` | OUT | 1 byte | Set slot output type (0=S/PDIF, 1=I2S; wValue=slot) |
+| `0xC1` | `REQ_GET_OUTPUT_TYPE` | IN | 1 byte | Get slot output type (wValue=slot) |
+| `0xC2` | `REQ_SET_I2S_BCK_PIN` | OUT | 1 byte | Set shared I2S BCK GPIO (LRCLK auto = BCK + 1) |
+| `0xC3` | `REQ_GET_I2S_BCK_PIN` | IN | 1 byte | Get current I2S BCK pin |
+| `0xC4` | `REQ_SET_MCK_ENABLE` | OUT | 1 byte | Enable/disable I2S master clock output |
+| `0xC5` | `REQ_GET_MCK_ENABLE` | IN | 1 byte | Get MCK enable state |
+| `0xC6` | `REQ_SET_MCK_PIN` | OUT | 1 byte | Set MCK GPIO |
+| `0xC7` | `REQ_GET_MCK_PIN` | IN | 1 byte | Get MCK GPIO |
+| `0xC8` | `REQ_SET_MCK_MULTIPLIER` | OUT | 1 byte | Set MCK multiplier (0=128×, 1=256×) |
+| `0xC9` | `REQ_GET_MCK_MULTIPLIER` | IN | 1 byte | Get MCK multiplier |
+| `0xD0` | `REQ_SET_PREAMP_CH` | OUT | 4 bytes | Set per-channel preamp (wValue=channel, payload=float dB) |
+| `0xD1` | `REQ_GET_PREAMP_CH` | IN | 4 bytes | Get per-channel preamp (wValue=channel) |
+| `0xD2` | `REQ_SET_MASTER_VOLUME` | OUT | 4 bytes | Set master volume (-128 mute sentinel, -127..0 dB) |
+| `0xD3` | `REQ_GET_MASTER_VOLUME` | IN | 4 bytes | Get current live master volume |
+| `0xD4` | `REQ_SET_MASTER_VOLUME_MODE` | OUT | 1 byte | Set persistence mode (0=independent, 1=with preset) |
+| `0xD5` | `REQ_GET_MASTER_VOLUME_MODE` | IN | 1 byte | Get persistence mode |
+| `0xD6` | `REQ_SAVE_MASTER_VOLUME` | IN | 1 byte | Save live master volume to directory (mode 0 persistence) |
+| `0xD7` | `REQ_GET_SAVED_MASTER_VOLUME` | IN | 4 bytes | Read directory's saved master-volume value |
+| `0xF0` | `REQ_ENTER_BOOTLOADER` | IN | 1 byte | Reboot into UF2 bootloader for firmware update |
 
 ### REQ_GET_STATUS (0x50) - System Telemetry
 
@@ -434,6 +543,13 @@ The `REQ_GET_STATUS` request returns data based on the `wValue` field:
 | `14` | uint32 | Core voltage (millivolts) |
 | `15` | uint32 | Sample rate (Hz) |
 | `16` | int32 | System temperature (centi-degrees C) |
+| `17` | uint32 | Total S/PDIF DMA starvations (all slots combined) |
+| `18` | uint32 | S/PDIF slot 0 starvations (Out 1-2) |
+| `19` | uint32 | S/PDIF slot 1 starvations (Out 3-4) |
+| `20` | uint32 | S/PDIF slot 2 starvations (Out 5-6, RP2350) |
+| `21` | uint32 | S/PDIF slot 3 starvations (Out 7-8, RP2350) |
+
+A starvation event means the S/PDIF DMA needed a buffer but the consumer pool was empty, so the firmware substituted a silence buffer for that transfer. This is a more direct output-side dropout signal than the older `spdif_underruns` USB-packet-gap heuristic.
 
 ### Data Structures
 
@@ -535,6 +651,32 @@ make
 ### 4. Flash the Device
 1.  Hold the **BOOTSEL** button on your board while plugging it in.
 2.  Drag and drop the generated `.uf2` file onto the `RPI-RP2` (or `RP2350`) drive.
+
+Alternatively, an already-running DSPi can be put into bootloader mode without a button press by sending `REQ_ENTER_BOOTLOADER` (0xF0). The DSPi Console application uses this for one-click firmware updates. See [`Documentation/Features/firmware_update.md`](Documentation/Features/firmware_update.md) for the protocol details.
+
+---
+
+## Detailed Specifications
+
+In-depth specs for each subsystem are kept under [`Documentation/Features/`](Documentation/Features/). These are the authoritative source for protocol formats, wire layouts, edge cases, and host-app integration patterns.
+
+| Feature | Spec |
+|---------|------|
+| Matrix Mixer | [`matrixmixer_spec.md`](Documentation/Features/matrixmixer_spec.md) |
+| User Presets | [`user_presets_spec.md`](Documentation/Features/user_presets_spec.md) |
+| Master Volume | [`master_volume_spec.md`](Documentation/Features/master_volume_spec.md) |
+| Per-Channel Preamp | [`per_channel_preamp_spec.md`](Documentation/Features/per_channel_preamp_spec.md) |
+| Volume Leveller | [`volume_leveller_spec.md`](Documentation/Features/volume_leveller_spec.md) |
+| I2S Output | [`i2s_output_spec.md`](Documentation/Features/i2s_output_spec.md) |
+| Peak / Clip Metering | [`peak_clip_metering_spec.md`](Documentation/Features/peak_clip_metering_spec.md) |
+| Buffer Statistics | [`buffer_statistics_spec.md`](Documentation/Features/buffer_statistics_spec.md) |
+| S/PDIF DMA Starvation | [`spdif_starvation_spec.md`](Documentation/Features/spdif_starvation_spec.md) |
+| USB Error Diagnostics | [`usb_errors_spec.md`](Documentation/Features/usb_errors_spec.md) |
+| Core 1 Modes | [`core1_modes_spec.md`](Documentation/Features/core1_modes_spec.md) |
+| Device Identification | [`device_identification_spec.md`](Documentation/Features/device_identification_spec.md) |
+| S/PDIF Input (planned) | [`SPDIF_input_spec.md`](Documentation/Features/SPDIF_input_spec.md) |
+| Firmware Update via USB | [`Documentation/Features/firmware_update.md`](Documentation/Features/firmware_update.md) |
+| Roadmap | [`roadmap.md`](Documentation/Features/roadmap.md) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ Configuration is performed via **Interface 2** (Vendor Interface) using Control 
 | Code | Name | Direction | Payload | Description |
 | :--- | :--- | :--- | :--- | :--- |
 | `0x42` | `REQ_SET_EQ_PARAM` | OUT | 16 bytes | Upload filter parameters |
-| `0x43` | `REQ_GET_EQ_PARAM` | IN | 16 bytes | Read filter parameters |
+| `0x43` | `REQ_GET_EQ_PARAM` | IN | **4 bytes** | Read one filter parameter. `wValue = (channel << 8) \| (band << 4) \| param` where `param`: `0`=type, `1`=freq, `2`=Q, `3`=gain. |
 | `0x44` | `REQ_SET_PREAMP` | OUT | 4 bytes | Set global gain (float dB) |
 | `0x45` | `REQ_GET_PREAMP` | IN | 4 bytes | Get global gain |
 | `0x46` | `REQ_SET_BYPASS` | OUT | 1 byte | Bypass Master EQ (1=On, 0=Off) |
@@ -567,6 +567,8 @@ struct __attribute__((packed)) {
     float gain_db;
 }
 ```
+
+> **Note on `REQ_GET_EQ_PARAM`:** Unlike `REQ_SET_EQ_PARAM`, the GET request returns **one field at a time**. Encode the desired field in the low nibble of `wValue` (`param = 0..3`) and read back 4 bytes. Four requests are required to reconstruct a full band.
 
 **Matrix Route Packet (8 bytes):**
 ```c

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -8,13 +8,17 @@ endif()
 # Always use local pico-extras (contains modified libraries)
 set(PICO_EXTRAS_PATH ${CMAKE_CURRENT_LIST_DIR}/pico-extras CACHE PATH "" FORCE)
 
-# Override the "pico" board's PICO_FLASH_SPI_CLKDIV=2 default.  DSPi overclocks
-# RP2040 to 307.2 MHz, making div=2 yield 153.6 MHz flash clock — above the
-# W25Q080's 104-133 MHz rated max.  Reads survive (single-shot at boot) but
-# erase/program can't be clocked reliably at that rate, and preset saves
-# silently fail verification.  Divider 6 → 51.2 MHz, safely within spec.
+# Override the "pico"/"pico2" boards' PICO_FLASH_SPI_CLKDIV=2 default.  DSPi
+# runs both platforms at 307.2 MHz, making div=2 yield a 153.6 MHz flash clock
+# — above the W25Q080's 104-133 MHz rated max.  Reads survive (single-shot at
+# boot) but erase/program can't be clocked reliably at that rate, and preset
+# saves silently fail verification.  Divider 6 → 51.2 MHz, safely within spec.
 # Must be set BEFORE pico_sdk_init() so it propagates to the boot2 build too.
 add_compile_definitions(PICO_FLASH_SPI_CLKDIV=6)
+# Note: PICO_FLASH_SPI_CLKDIV only reaches hardware on RP2040 (via boot2's SSI
+# setup).  On RP2350, boot2 isn't executed at all by default, and the ROM's own
+# XIP setup (CLKDIV≈3) stays in force.  The RP2350 override is done at runtime
+# in DSPi/flash_clkdiv.c by writing QMI registers directly.
 
 # Pull in PICO SDK (must be before project)
 include(pico_sdk_import.cmake)

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -8,6 +8,14 @@ endif()
 # Always use local pico-extras (contains modified libraries)
 set(PICO_EXTRAS_PATH ${CMAKE_CURRENT_LIST_DIR}/pico-extras CACHE PATH "" FORCE)
 
+# Override the "pico" board's PICO_FLASH_SPI_CLKDIV=2 default.  DSPi overclocks
+# RP2040 to 307.2 MHz, making div=2 yield 153.6 MHz flash clock — above the
+# W25Q080's 104-133 MHz rated max.  Reads survive (single-shot at boot) but
+# erase/program can't be clocked reliably at that rate, and preset saves
+# silently fail verification.  Divider 6 → 51.2 MHz, safely within spec.
+# Must be set BEFORE pico_sdk_init() so it propagates to the boot2 build too.
+add_compile_definitions(PICO_FLASH_SPI_CLKDIV=6)
+
 # Pull in PICO SDK (must be before project)
 include(pico_sdk_import.cmake)
 

--- a/firmware/DSPi/CMakeLists.txt
+++ b/firmware/DSPi/CMakeLists.txt
@@ -18,6 +18,8 @@ add_executable(DSPi
     dcp_inline.h
     dsp_pipeline.c
     dsp_pipeline.h
+    flash_clkdiv.c
+    flash_clkdiv.h
     flash_storage.c
     flash_storage.h
     leveller.c

--- a/firmware/DSPi/config.h
+++ b/firmware/DSPi/config.h
@@ -227,13 +227,24 @@ extern volatile uint32_t nominal_feedback_10_14;
 // Master Volume Commands
 #define REQ_SET_MASTER_VOLUME       0xD2  // payload = float dB (-128 mute sentinel, -127..0 range)
 #define REQ_GET_MASTER_VOLUME       0xD3  // returns float dB
-#define REQ_SET_INCLUDE_MASTER_VOL  0xD4  // payload = uint8_t (0/1), controls preset load behavior
-#define REQ_GET_INCLUDE_MASTER_VOL  0xD5  // returns uint8_t
+#define REQ_SET_MASTER_VOLUME_MODE  0xD4  // payload = uint8_t mode (see MASTER_VOLUME_MODE_*)
+#define REQ_GET_MASTER_VOLUME_MODE  0xD5  // returns uint8_t mode
+#define REQ_SAVE_MASTER_VOLUME      0xD6  // no payload, stores live master vol to directory
+#define REQ_GET_SAVED_MASTER_VOLUME 0xD7  // returns float dB from directory's independent field
 
 // Master Volume Constants
 #define MASTER_VOL_MUTE_DB          (-128.0f)  // Sentinel value: true -inf (mute)
 #define MASTER_VOL_MIN_DB           (-127.0f)  // Minimum non-mute attenuation
 #define MASTER_VOL_MAX_DB           (0.0f)     // Unity gain (no attenuation)
+
+// Master Volume Persistence Modes
+// Mode 0 (default): master volume is independent of presets. REQ_SAVE_MASTER_VOLUME
+//   stores it in the directory sector; it's applied at boot and on factory reset.
+//   Preset save/load does not touch it.
+// Mode 1: master volume is part of the preset. Saved with the preset, restored on
+//   preset load — same as the old include_master_volume=1 behavior.
+#define MASTER_VOLUME_MODE_INDEPENDENT   0
+#define MASTER_VOLUME_MODE_WITH_PRESET   1
 
 // System
 #define REQ_ENTER_BOOTLOADER        0xF0

--- a/firmware/DSPi/config.h
+++ b/firmware/DSPi/config.h
@@ -236,6 +236,7 @@ extern volatile uint32_t nominal_feedback_10_14;
 #define MASTER_VOL_MUTE_DB          (-128.0f)  // Sentinel value: true -inf (mute)
 #define MASTER_VOL_MIN_DB           (-127.0f)  // Minimum non-mute attenuation
 #define MASTER_VOL_MAX_DB           (0.0f)     // Unity gain (no attenuation)
+#define MASTER_VOL_DEFAULT_DB       (-20.0f)   // Power-on / fresh-device default
 
 // Master Volume Persistence Modes
 // Mode 0 (default): master volume is independent of presets. REQ_SAVE_MASTER_VOLUME

--- a/firmware/DSPi/flash_clkdiv.c
+++ b/firmware/DSPi/flash_clkdiv.c
@@ -1,0 +1,105 @@
+#include "flash_clkdiv.h"
+
+#include "hardware/flash.h"
+#include "hardware/sync.h"
+#include "pico/bootrom.h"
+
+#if PICO_RP2350
+
+#include "hardware/structs/qmi.h"
+#include "hardware/regs/qmi.h"
+
+#define DSPI_FLASH_SPI_CLKDIV   6
+#define FLASH_BLOCK_ERASE_CMD   0xd8
+
+// Force CLKDIV=6 into the two registers that matter:
+//   - DIRECT_CSR.CLKDIV: the ROM's direct-mode serial commands (erase/program)
+//   - M0_TIMING.CLKDIV:  XIP reads once we leave direct mode
+// Other fields (RXDELAY, COOLDOWN, RCMD/RFMT) are preserved via hw_write_masked.
+static void __no_inline_not_in_flash_func(dspi_set_clkdiv)(void) {
+    hw_write_masked(&qmi_hw->direct_csr,
+                    DSPI_FLASH_SPI_CLKDIV << QMI_DIRECT_CSR_CLKDIV_LSB,
+                    QMI_DIRECT_CSR_CLKDIV_BITS);
+    hw_write_masked(&qmi_hw->m[0].timing,
+                    DSPI_FLASH_SPI_CLKDIV << QMI_M0_TIMING_CLKDIV_LSB,
+                    QMI_M0_TIMING_CLKDIV_BITS);
+    __compiler_memory_barrier();
+}
+
+void dspi_flash_apply_clkdiv(void) { dspi_set_clkdiv(); }
+
+// Re-implements SDK flash_range_erase/program but:
+//   1) snapshots QMI m[0] before the ROM calls (the ROM clobbers RCMD/RFMT/
+//      TIMING — same pattern as pico-sdk #1983's m[1]/PSRAM workaround),
+//   2) forces CLKDIV=6 *inside* the flash op (between flash_exit_xip and the
+//      ROM erase/program call, so writes also run at 51.2 MHz not the ROM
+//      default ~102 MHz),
+//   3) restores the saved RCMD/RFMT so XIP reads stay in quad continuous
+//      mode, with our CLKDIV=6 overlaid on the preserved TIMING.
+// Caller is responsible for interrupts-off + Core 1 parked, same contract as
+// the SDK's flash_range_erase/program.
+void __no_inline_not_in_flash_func(dspi_flash_range_erase)(uint32_t flash_offs, size_t count) {
+    rom_connect_internal_flash_fn connect     = (rom_connect_internal_flash_fn) rom_func_lookup_inline(ROM_FUNC_CONNECT_INTERNAL_FLASH);
+    rom_flash_exit_xip_fn         exit_xip    = (rom_flash_exit_xip_fn)         rom_func_lookup_inline(ROM_FUNC_FLASH_EXIT_XIP);
+    rom_flash_range_erase_fn      range_erase = (rom_flash_range_erase_fn)      rom_func_lookup_inline(ROM_FUNC_FLASH_RANGE_ERASE);
+    rom_flash_flush_cache_fn      flush_cache = (rom_flash_flush_cache_fn)      rom_func_lookup_inline(ROM_FUNC_FLASH_FLUSH_CACHE);
+
+    uint32_t saved_timing = qmi_hw->m[0].timing;
+    uint32_t saved_rcmd   = qmi_hw->m[0].rcmd;
+    uint32_t saved_rfmt   = qmi_hw->m[0].rfmt;
+
+    __compiler_memory_barrier();
+    connect();
+    exit_xip();
+    dspi_set_clkdiv();
+    range_erase(flash_offs, count, FLASH_BLOCK_SIZE, FLASH_BLOCK_ERASE_CMD);
+    flush_cache();
+
+    qmi_hw->m[0].rcmd   = saved_rcmd;
+    qmi_hw->m[0].rfmt   = saved_rfmt;
+    qmi_hw->m[0].timing = (saved_timing & ~QMI_M0_TIMING_CLKDIV_BITS)
+                        | (DSPI_FLASH_SPI_CLKDIV << QMI_M0_TIMING_CLKDIV_LSB);
+    __compiler_memory_barrier();
+}
+
+void __no_inline_not_in_flash_func(dspi_flash_range_program)(uint32_t flash_offs, const uint8_t *data, size_t count) {
+    rom_connect_internal_flash_fn connect       = (rom_connect_internal_flash_fn) rom_func_lookup_inline(ROM_FUNC_CONNECT_INTERNAL_FLASH);
+    rom_flash_exit_xip_fn         exit_xip      = (rom_flash_exit_xip_fn)         rom_func_lookup_inline(ROM_FUNC_FLASH_EXIT_XIP);
+    rom_flash_range_program_fn    range_program = (rom_flash_range_program_fn)    rom_func_lookup_inline(ROM_FUNC_FLASH_RANGE_PROGRAM);
+    rom_flash_flush_cache_fn      flush_cache   = (rom_flash_flush_cache_fn)      rom_func_lookup_inline(ROM_FUNC_FLASH_FLUSH_CACHE);
+
+    uint32_t saved_timing = qmi_hw->m[0].timing;
+    uint32_t saved_rcmd   = qmi_hw->m[0].rcmd;
+    uint32_t saved_rfmt   = qmi_hw->m[0].rfmt;
+
+    __compiler_memory_barrier();
+    connect();
+    exit_xip();
+    dspi_set_clkdiv();
+    range_program(flash_offs, data, count);
+    flush_cache();
+
+    qmi_hw->m[0].rcmd   = saved_rcmd;
+    qmi_hw->m[0].rfmt   = saved_rfmt;
+    qmi_hw->m[0].timing = (saved_timing & ~QMI_M0_TIMING_CLKDIV_BITS)
+                        | (DSPI_FLASH_SPI_CLKDIV << QMI_M0_TIMING_CLKDIV_LSB);
+    __compiler_memory_barrier();
+}
+
+#else  // PICO_RP2040
+
+// On RP2040, boot2's PICO_FLASH_SPI_CLKDIV already governs both XIP reads and
+// the SSI clock the bootrom uses for erase/program (via flash_enable_xip_via_boot2
+// trampolining through boot2 around each op).  Nothing extra to do.
+
+void dspi_flash_apply_clkdiv(void) {}
+
+void dspi_flash_range_erase(uint32_t flash_offs, size_t count) {
+    flash_range_erase(flash_offs, count);
+}
+
+void dspi_flash_range_program(uint32_t flash_offs, const uint8_t *data, size_t count) {
+    flash_range_program(flash_offs, data, count);
+}
+
+#endif

--- a/firmware/DSPi/flash_clkdiv.h
+++ b/firmware/DSPi/flash_clkdiv.h
@@ -1,0 +1,27 @@
+#ifndef FLASH_CLKDIV_H
+#define FLASH_CLKDIV_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Wrappers around hardware_flash that force QMI CLKDIV=6 for both XIP reads
+// and the ROM's direct-mode erase/program on RP2350.  On RP2040 they forward
+// to the SDK — boot2's PICO_FLASH_SPI_CLKDIV already governs both there.
+//
+// Rationale: PICO_FLASH_SPI_CLKDIV only reaches hardware on RP2040 (via
+// boot2).  On RP2350 boot2 isn't run by default, so we program QMI
+// directly: apply CLKDIV=6 once at startup for XIP reads, and save/restore
+// m[0] around each flash op (the ROM clobbers it) with CLKDIV=6 overlaid.
+void dspi_flash_apply_clkdiv(void);
+void dspi_flash_range_erase(uint32_t flash_offs, size_t count);
+void dspi_flash_range_program(uint32_t flash_offs, const uint8_t *data, size_t count);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/firmware/DSPi/flash_storage.c
+++ b/firmware/DSPi/flash_storage.c
@@ -406,7 +406,7 @@ static bool dir_load_cache(void) {
         dir_cache.master_volume_mode = v1->include_master_volume
                                          ? MASTER_VOLUME_MODE_WITH_PRESET
                                          : MASTER_VOLUME_MODE_INDEPENDENT;
-        dir_cache.master_volume_db   = MASTER_VOL_MAX_DB;
+        dir_cache.master_volume_db   = MASTER_VOL_DEFAULT_DB;
         memcpy(dir_cache.slot_names, v1->slot_names, sizeof(dir_cache.slot_names));
         dir_cache_valid = true;
         (void)dir_flush();  // persist as v2; if the flush fails, cache stays valid in RAM
@@ -448,7 +448,7 @@ static void dir_ensure(void) {
     dir_cache.last_active_slot = 0;     // Default to slot 0
     dir_cache.include_pins = 1;              // Include pins in preset load by default
     dir_cache.master_volume_mode = MASTER_VOLUME_MODE_INDEPENDENT;
-    dir_cache.master_volume_db   = MASTER_VOL_MAX_DB;
+    dir_cache.master_volume_db   = MASTER_VOL_DEFAULT_DB;
     dir_cache.slot_occupied = 0;             // All slots empty
     // Slot 0 gets a default name; others are empty (already zeroed by memset)
     strncpy(dir_cache.slot_names[0], "Default", PRESET_NAME_LEN - 1);
@@ -1032,7 +1032,7 @@ static bool migrate_legacy(void) {
     dir_cache.last_active_slot = 0;
     dir_cache.include_pins = 1;
     dir_cache.master_volume_mode = MASTER_VOLUME_MODE_INDEPENDENT;
-    dir_cache.master_volume_db   = MASTER_VOL_MAX_DB;
+    dir_cache.master_volume_db   = MASTER_VOL_DEFAULT_DB;
     dir_cache.slot_occupied = 0x0001;  // Slot 0 occupied
     strncpy(dir_cache.slot_names[0], "Migrated", PRESET_NAME_LEN - 1);
     dir_cache_valid = true;

--- a/firmware/DSPi/flash_storage.c
+++ b/firmware/DSPi/flash_storage.c
@@ -273,16 +273,15 @@ static uint32_t crc32(const uint8_t *data, size_t len) {
 // dB-TO-LINEAR CONVERSION (no powf dependency in flash context)
 // ============================================================================
 
-// Compute 10^(db/20) using Taylor-series approximation of exp().
-// Accurate to <0.1 dB across the [-60, +20] dB range.
+// Compute 10^(db/20).  An earlier 4-term Taylor approximation here was
+// catastrophically wrong beyond ~±10 dB (at -60 dB it returned ~58 instead
+// of 0.001, producing loud/distorted output after preset load with any
+// deeply-negative gain — see preamp/gain/matrix paths below).  powf is fine:
+// this function runs from flash after XIP is up, no RAM-residency constraint.
 static float db_to_linear(float db) {
-    if (db == 0.0f) return 1.0f;
-    if (db < -60.0f) db = -60.0f;
-    if (db > 20.0f) db = 20.0f;
-    // 10^(db/20) = e^(db * ln(10)/20)
-    float x = db * 0.1151292546f;  // ln(10)/20
-    float linear = 1.0f + x + x*x*0.5f + x*x*x*0.1666667f + x*x*x*x*0.0416667f;
-    return (linear < 0.0f) ? 0.0f : linear;
+    if (db <= -120.0f) return 0.0f;
+    if (db >=  +80.0f) db = 80.0f;
+    return powf(10.0f, db / 20.0f);
 }
 
 // ============================================================================

--- a/firmware/DSPi/flash_storage.c
+++ b/firmware/DSPi/flash_storage.c
@@ -91,10 +91,28 @@ typedef struct __attribute__((packed)) {
     float delay_ms;
 } FlashOutputChannel;
 
-// --- Preset Directory (sector 0) ---
+// --- Preset Directory v1 (legacy — kept only for upgrade migration) ---
+typedef struct __attribute__((packed)) {
+    uint32_t magic;
+    uint16_t version;                        // == 1
+    uint16_t reserved;
+    uint32_t crc32;
+
+    uint8_t  startup_mode;
+    uint8_t  default_slot;
+    uint8_t  last_active_slot;
+    uint8_t  include_pins;
+
+    uint16_t slot_occupied;
+    uint8_t  include_master_volume;
+    uint8_t  padding[1];
+    char     slot_names[PRESET_SLOTS][PRESET_NAME_LEN];
+} PresetDirectory_v1;
+
+// --- Preset Directory v2 (current, sector 0) ---
 typedef struct __attribute__((packed)) {
     uint32_t magic;                          // DIR_MAGIC
-    uint16_t version;                        // Directory format version (1)
+    uint16_t version;                        // Directory format version (2)
     uint16_t reserved;
     uint32_t crc32;                          // CRC over everything after this 12-byte header
 
@@ -106,10 +124,13 @@ typedef struct __attribute__((packed)) {
 
     // Slot metadata
     uint16_t slot_occupied;                  // Bitmask: bit N = slot N has valid data
-    uint8_t  include_master_volume;          // Whether preset load restores master volume (was padding[0])
-    uint8_t  padding[1];                     // Remaining padding (was padding[1])
+    uint8_t  master_volume_mode;             // MASTER_VOLUME_MODE_INDEPENDENT or _WITH_PRESET
+    uint8_t  padding[1];
+    float    master_volume_db;               // Independent master volume (mode 0 at boot)
     char     slot_names[PRESET_SLOTS][PRESET_NAME_LEN];  // 32-byte NUL-terminated names
 } PresetDirectory;
+
+#define DIR_VERSION_CURRENT  2
 
 // --- Preset Slot (sectors 1-10) ---
 typedef struct __attribute__((packed)) {
@@ -340,30 +361,68 @@ static int flash_write_sector(uint32_t offset, const void *data, size_t len) {
 // ============================================================================
 
 // Load the directory from flash into the RAM cache.
-// Returns true if a valid directory was found.
+// Returns true if a valid directory was found.  Transparently migrates a v1
+// directory to v2 on first boot of new firmware, preserving slot names,
+// startup config, and the old include_master_volume flag (which maps 1:1 to
+// master_volume_mode).  The independent master_volume_db defaults to
+// MASTER_VOL_MAX_DB so boot-time audible behavior is unchanged post-upgrade.
+static int dir_flush(void);  // forward decl — migration calls it
 static bool dir_load_cache(void) {
     const PresetDirectory *flash_dir = DIR_ADDR;
     if (flash_dir->magic != DIR_MAGIC) {
         dir_cache_valid = false;
         return false;
     }
-    // Verify CRC (covers everything after the 12-byte header)
-    const uint8_t *data_start = (const uint8_t *)&flash_dir->startup_mode;
-    size_t data_len = sizeof(PresetDirectory) - offsetof(PresetDirectory, startup_mode);
-    if (crc32(data_start, data_len) != flash_dir->crc32) {
-        dir_cache_valid = false;
-        return false;
+
+    if (flash_dir->version == DIR_VERSION_CURRENT) {
+        // Current format — CRC covers everything after the 12-byte header.
+        const uint8_t *data_start = (const uint8_t *)&flash_dir->startup_mode;
+        size_t data_len = sizeof(PresetDirectory) - offsetof(PresetDirectory, startup_mode);
+        if (crc32(data_start, data_len) != flash_dir->crc32) {
+            dir_cache_valid = false;
+            return false;
+        }
+        memcpy(&dir_cache, flash_dir, sizeof(dir_cache));
+        dir_cache_valid = true;
+        return true;
     }
-    memcpy(&dir_cache, flash_dir, sizeof(dir_cache));
-    dir_cache_valid = true;
-    return true;
+
+    if (flash_dir->version == 1) {
+        // Legacy v1 format — read with the old struct, validate old CRC,
+        // then migrate to v2 in memory and flush.
+        const PresetDirectory_v1 *v1 = (const PresetDirectory_v1 *)flash_dir;
+        const uint8_t *v1_data_start = (const uint8_t *)&v1->startup_mode;
+        size_t v1_data_len = sizeof(PresetDirectory_v1) - offsetof(PresetDirectory_v1, startup_mode);
+        if (crc32(v1_data_start, v1_data_len) != v1->crc32) {
+            dir_cache_valid = false;
+            return false;
+        }
+        memset(&dir_cache, 0, sizeof(dir_cache));
+        dir_cache.startup_mode       = v1->startup_mode;
+        dir_cache.default_slot       = v1->default_slot;
+        dir_cache.last_active_slot   = v1->last_active_slot;
+        dir_cache.include_pins       = v1->include_pins;
+        dir_cache.slot_occupied      = v1->slot_occupied;
+        dir_cache.master_volume_mode = v1->include_master_volume
+                                         ? MASTER_VOLUME_MODE_WITH_PRESET
+                                         : MASTER_VOLUME_MODE_INDEPENDENT;
+        dir_cache.master_volume_db   = MASTER_VOL_MAX_DB;
+        memcpy(dir_cache.slot_names, v1->slot_names, sizeof(dir_cache.slot_names));
+        dir_cache_valid = true;
+        (void)dir_flush();  // persist as v2; if the flush fails, cache stays valid in RAM
+        return true;
+    }
+
+    // Unknown future version — treat as invalid.
+    dir_cache_valid = false;
+    return false;
 }
 
 // Write the RAM-cached directory back to flash.
 // Recomputes the CRC before writing.
 static int dir_flush(void) {
     dir_cache.magic = DIR_MAGIC;
-    dir_cache.version = 1;
+    dir_cache.version = DIR_VERSION_CURRENT;
     dir_cache.reserved = 0;
     // CRC covers everything after the 12-byte header (magic + version + reserved + crc32)
     const uint8_t *data_start = (const uint8_t *)&dir_cache.startup_mode;
@@ -388,7 +447,8 @@ static void dir_ensure(void) {
     dir_cache.default_slot = 0;
     dir_cache.last_active_slot = 0;     // Default to slot 0
     dir_cache.include_pins = 1;              // Include pins in preset load by default
-    dir_cache.include_master_volume = 0;     // Don't include master volume by default
+    dir_cache.master_volume_mode = MASTER_VOLUME_MODE_INDEPENDENT;
+    dir_cache.master_volume_db   = MASTER_VOL_MAX_DB;
     dir_cache.slot_occupied = 0;             // All slots empty
     // Slot 0 gets a default name; others are empty (already zeroed by memset)
     strncpy(dir_cache.slot_names[0], "Default", PRESET_NAME_LEN - 1);
@@ -491,12 +551,50 @@ static void collect_live_state(PresetSlot *slot, uint8_t slot_index) {
     slot->crc32 = crc32(data_start, data_len);
 }
 
+// Apply a dB value to the live master volume globals, clamped and with
+// NaN/Inf defended.  Shared between mode-0 (directory) and mode-1 (preset)
+// apply paths.  Uses powf() because db_to_linear() clamps at -60 dB and the
+// master volume range extends to MASTER_VOL_MUTE_DB (-128).
+static void apply_master_volume_db(float db) {
+    if (!isfinite(db)) db = MASTER_VOL_MAX_DB;
+    if (db < MASTER_VOL_MUTE_DB) db = MASTER_VOL_MUTE_DB;
+    if (db > MASTER_VOL_MAX_DB)  db = MASTER_VOL_MAX_DB;
+    master_volume_db = db;
+    if (db <= MASTER_VOL_MUTE_DB) {
+        master_volume_linear = 0.0f;
+        master_volume_q15    = 0;
+    } else {
+        float linear = powf(10.0f, db / 20.0f);
+        master_volume_linear = linear;
+        master_volume_q15    = (int32_t)(linear * 32768.0f);
+    }
+}
+
+// Decide which dB value to apply to master volume based on current mode.
+//   mode 0 (independent): use dir_cache.master_volume_db, which was set
+//     either by a prior REQ_SAVE_MASTER_VOLUME or by fresh-directory init.
+//   mode 1 (per-preset):  use slot->master_volume_db if available (V12+).
+//     Falls back to the directory value for older slots so we never leave
+//     the live globals at a stale value from a previous load.
+// `slot_or_null` may be NULL (e.g. factory-defaults path with no slot).
+static void apply_master_volume_from_mode(const PresetSlot *slot_or_null) {
+    float db;
+    if (dir_cache.master_volume_mode == MASTER_VOLUME_MODE_WITH_PRESET
+        && slot_or_null && slot_or_null->version >= 12) {
+        db = slot_or_null->master_volume_db;
+    } else {
+        db = dir_cache.master_volume_db;
+    }
+    apply_master_volume_db(db);
+}
+
 // Apply a validated PresetSlot to the live DSP state.
 // `include_pins` controls whether pin config is restored.
-// `include_master_vol` controls whether master volume is restored.
+// Master volume is *not* touched here — callers invoke
+// apply_master_volume_from_mode() separately after this returns, so mode
+// changes don't require a preset reload to take effect.
 // Does NOT trigger filter recalculation — caller must do that.
-static void apply_slot_to_live(const PresetSlot *slot, bool include_pins,
-                               bool include_master_vol) {
+static void apply_slot_to_live(const PresetSlot *slot, bool include_pins) {
     // EQ
     memcpy((void *)filter_recipes, slot->filter_recipes, sizeof(filter_recipes));
 
@@ -515,25 +613,6 @@ static void apply_slot_to_live(const PresetSlot *slot, bool include_pins,
             float linear = db_to_linear(slot->preamp_db);
             global_preamp_mul[i] = (int32_t)(linear * (float)(1 << 28));
             global_preamp_linear[i] = linear;
-        }
-    }
-
-    // Master volume — only restored if the directory flag allows it and slot is V12+.
-    // Uses powf() instead of db_to_linear() because db_to_linear() clamps at -60 dB
-    // and master volume ranges to -127 dB.
-    if (include_master_vol && slot->version >= 12) {
-        float db = slot->master_volume_db;
-        if (!isfinite(db)) db = MASTER_VOL_MAX_DB;  // NaN/Inf → unity (safe default)
-        if (db < MASTER_VOL_MUTE_DB) db = MASTER_VOL_MUTE_DB;
-        if (db > MASTER_VOL_MAX_DB)  db = MASTER_VOL_MAX_DB;
-        master_volume_db = db;
-        if (db <= MASTER_VOL_MUTE_DB) {
-            master_volume_linear = 0.0f;
-            master_volume_q15    = 0;
-        } else {
-            float linear = powf(10.0f, db / 20.0f);
-            master_volume_linear = linear;
-            master_volume_q15    = (int32_t)(linear * 32768.0f);
         }
     }
 
@@ -727,8 +806,8 @@ uint8_t preset_load(uint8_t slot) {
             preset_loading = false;
             return PRESET_ERR_CRC;
         }
-        apply_slot_to_live(s, dir_cache.include_pins != 0,
-                               dir_cache.include_master_volume != 0);
+        apply_slot_to_live(s, dir_cache.include_pins != 0);
+        apply_master_volume_from_mode(s);
     } else {
         // Slot not configured — apply factory defaults
         apply_factory_defaults();
@@ -850,14 +929,14 @@ uint8_t preset_set_name(uint8_t slot, const char *name) {
 
 void preset_get_directory(uint16_t *slot_occupied, uint8_t *startup_mode,
                           uint8_t *default_slot, uint8_t *last_active,
-                          uint8_t *include_pins, uint8_t *include_master_volume) {
+                          uint8_t *include_pins, uint8_t *master_volume_mode) {
     dir_ensure();
-    *slot_occupied = dir_cache.slot_occupied;
-    *startup_mode = dir_cache.startup_mode;
-    *default_slot = dir_cache.default_slot;
-    *last_active = dir_cache.last_active_slot;
-    *include_pins = dir_cache.include_pins;
-    *include_master_volume = dir_cache.include_master_volume;
+    *slot_occupied      = dir_cache.slot_occupied;
+    *startup_mode       = dir_cache.startup_mode;
+    *default_slot       = dir_cache.default_slot;
+    *last_active        = dir_cache.last_active_slot;
+    *include_pins       = dir_cache.include_pins;
+    *master_volume_mode = dir_cache.master_volume_mode;
 }
 
 uint8_t preset_set_startup(uint8_t mode, uint8_t default_slot) {
@@ -879,10 +958,29 @@ void preset_set_include_pins(uint8_t include) {
     dir_flush();
 }
 
-void preset_set_include_master_volume(uint8_t include) {
+void preset_set_master_volume_mode(uint8_t mode) {
+    if (mode > MASTER_VOLUME_MODE_WITH_PRESET) mode = MASTER_VOLUME_MODE_INDEPENDENT;
     dir_ensure();
-    dir_cache.include_master_volume = include ? 1 : 0;
+    dir_cache.master_volume_mode = mode;
     dir_flush();
+}
+
+// Copy the live master volume into the directory's independent field and
+// persist.  Accepted in both modes — in mode 1 the value is dormant until
+// the user switches to mode 0.  Matches the deferred-flush machinery used
+// for the other directory-writing setters.
+uint8_t preset_save_master_volume(void) {
+    dir_ensure();
+    dir_cache.master_volume_db = master_volume_db;
+    if (dir_flush() != 0) return PRESET_ERR_FLASH_WRITE;
+    return PRESET_OK;
+}
+
+// Read back the directory's independent master volume field (the value that
+// would apply at boot in mode 0).  Does not touch live globals.
+float preset_get_saved_master_volume(void) {
+    dir_ensure();
+    return dir_cache.master_volume_db;
 }
 
 uint8_t preset_get_active(void) {
@@ -933,7 +1031,8 @@ static bool migrate_legacy(void) {
     dir_cache.default_slot = 0;
     dir_cache.last_active_slot = 0;
     dir_cache.include_pins = 1;
-    dir_cache.include_master_volume = 0;
+    dir_cache.master_volume_mode = MASTER_VOLUME_MODE_INDEPENDENT;
+    dir_cache.master_volume_db   = MASTER_VOL_MAX_DB;
     dir_cache.slot_occupied = 0x0001;  // Slot 0 occupied
     strncpy(dir_cache.slot_names[0], "Migrated", PRESET_NAME_LEN - 1);
     dir_cache_valid = true;
@@ -968,8 +1067,8 @@ int preset_boot_load(void) {
         if ((dir_cache.slot_occupied & (1u << target_slot))) {
             const PresetSlot *s = validate_slot(target_slot);
             if (s) {
-                apply_slot_to_live(s, dir_cache.include_pins != 0,
-                               dir_cache.include_master_volume != 0);
+                apply_slot_to_live(s, dir_cache.include_pins != 0);
+                apply_master_volume_from_mode(s);
             } else {
                 // Corrupt data — fall back to factory defaults
                 apply_factory_defaults();
@@ -987,7 +1086,8 @@ int preset_boot_load(void) {
         // Migration succeeded; slot 0 is now populated.  Load it.
         const PresetSlot *s = validate_slot(0);
         if (s) {
-            apply_slot_to_live(s, false, false);  // Legacy migration: don't override pins or master vol
+            apply_slot_to_live(s, false);  // Legacy migration: don't override pins
+            apply_master_volume_from_mode(s);
         } else {
             apply_factory_defaults();
         }
@@ -1051,10 +1151,10 @@ static void apply_factory_defaults(void) {
         global_preamp_linear[i]  = 1.0f;
     }
 
-    // Master volume — reset to unity (no attenuation)
-    master_volume_db     = MASTER_VOL_MAX_DB;
-    master_volume_linear = 1.0f;
-    master_volume_q15    = 32768;
+    // Master volume — defer to the mode-aware helper so mode 0 restores the
+    // directory's independent value instead of always stomping to unity.
+    // (Mode 1 with slot_or_null=NULL also falls back to the directory value.)
+    apply_master_volume_from_mode(NULL);
 
     // Bypass
     bypass_master_eq = false;

--- a/firmware/DSPi/flash_storage.c
+++ b/firmware/DSPi/flash_storage.c
@@ -28,6 +28,7 @@
 #include "flash_storage.h"
 #include "config.h"
 #include "dsp_pipeline.h"
+#include "flash_clkdiv.h"
 #include "usb_audio.h"
 #include "crossfeed.h"
 #include "pdm_generator.h"
@@ -311,8 +312,8 @@ static int flash_write_sector(uint32_t offset, const void *data, size_t len) {
     if (do_lockout) multicore_lockout_start_blocking();
 
     uint32_t flags = save_and_disable_interrupts();
-    flash_range_erase(offset, FLASH_SECTOR_SIZE);
-    flash_range_program(offset, write_buf, write_size);
+    dspi_flash_range_erase(offset, FLASH_SECTOR_SIZE);
+    dspi_flash_range_program(offset, write_buf, write_size);
     restore_interrupts(flags);
 
     if (do_lockout) multicore_lockout_end_blocking();
@@ -784,7 +785,7 @@ uint8_t preset_delete(uint8_t slot) {
     if (do_lockout) multicore_lockout_start_blocking();
 
     uint32_t flags = save_and_disable_interrupts();
-    flash_range_erase(SLOT_SECTOR_OFFSET(slot), FLASH_SECTOR_SIZE);
+    dspi_flash_range_erase(SLOT_SECTOR_OFFSET(slot), FLASH_SECTOR_SIZE);
     restore_interrupts(flags);
 
     if (do_lockout) multicore_lockout_end_blocking();

--- a/firmware/DSPi/flash_storage.c
+++ b/firmware/DSPi/flash_storage.c
@@ -388,7 +388,7 @@ static void dir_ensure(void) {
     dir_cache.startup_mode = PRESET_STARTUP_SPECIFIED;
     dir_cache.default_slot = 0;
     dir_cache.last_active_slot = 0;     // Default to slot 0
-    dir_cache.include_pins = 0;              // Don't include pins by default
+    dir_cache.include_pins = 1;              // Include pins in preset load by default
     dir_cache.include_master_volume = 0;     // Don't include master volume by default
     dir_cache.slot_occupied = 0;             // All slots empty
     // Slot 0 gets a default name; others are empty (already zeroed by memset)
@@ -933,7 +933,7 @@ static bool migrate_legacy(void) {
     dir_cache.startup_mode = PRESET_STARTUP_SPECIFIED;
     dir_cache.default_slot = 0;
     dir_cache.last_active_slot = 0;
-    dir_cache.include_pins = 0;
+    dir_cache.include_pins = 1;
     dir_cache.include_master_volume = 0;
     dir_cache.slot_occupied = 0x0001;  // Slot 0 occupied
     strncpy(dir_cache.slot_names[0], "Migrated", PRESET_NAME_LEN - 1);

--- a/firmware/DSPi/flash_storage.h
+++ b/firmware/DSPi/flash_storage.h
@@ -58,15 +58,15 @@ uint8_t preset_get_name(uint8_t slot, char *name_out);
 uint8_t preset_set_name(uint8_t slot, const char *name);
 
 // Get a summary of the preset directory:
-//   - slot_occupied:        16-bit bitmask (bit N = slot N occupied)
-//   - startup_mode:         PRESET_STARTUP_SPECIFIED or PRESET_STARTUP_LAST_ACTIVE
-//   - default_slot:         slot loaded in SPECIFIED mode (0-9)
-//   - last_active:          last slot that was loaded/saved (always 0-9)
-//   - include_pins:         whether preset load restores pin config (0/1)
-//   - include_master_volume: whether preset load restores master volume (0/1)
+//   - slot_occupied:       16-bit bitmask (bit N = slot N occupied)
+//   - startup_mode:        PRESET_STARTUP_SPECIFIED or PRESET_STARTUP_LAST_ACTIVE
+//   - default_slot:        slot loaded in SPECIFIED mode (0-9)
+//   - last_active:         last slot that was loaded/saved (always 0-9)
+//   - include_pins:        whether preset load restores pin config (0/1)
+//   - master_volume_mode:  MASTER_VOLUME_MODE_INDEPENDENT (0) or _WITH_PRESET (1)
 void preset_get_directory(uint16_t *slot_occupied, uint8_t *startup_mode,
                           uint8_t *default_slot, uint8_t *last_active,
-                          uint8_t *include_pins, uint8_t *include_master_volume);
+                          uint8_t *include_pins, uint8_t *master_volume_mode);
 
 // Set startup behavior.
 //   mode: PRESET_STARTUP_SPECIFIED or PRESET_STARTUP_LAST_ACTIVE
@@ -77,8 +77,18 @@ uint8_t preset_set_startup(uint8_t mode, uint8_t default_slot);
 // Set whether preset load/save includes pin configuration.
 void preset_set_include_pins(uint8_t include);
 
-// Set whether preset load restores master volume from the preset.
-void preset_set_include_master_volume(uint8_t include);
+// Set the master-volume persistence mode (0 = independent, 1 = per-preset).
+// Values outside the valid range are clamped to INDEPENDENT.
+void preset_set_master_volume_mode(uint8_t mode);
+
+// Copy the live master volume into the directory's independent field and
+// persist.  Accepted regardless of current mode (dormant in mode 1).
+// Returns PRESET_OK or PRESET_ERR_FLASH_WRITE.
+uint8_t preset_save_master_volume(void);
+
+// Read the directory's independent master-volume field (the value applied at
+// boot in mode 0).  Does not affect live state.
+float preset_get_saved_master_volume(void);
 
 // Get the currently active preset slot (always 0-9).
 uint8_t preset_get_active(void);

--- a/firmware/DSPi/main.c
+++ b/firmware/DSPi/main.c
@@ -18,6 +18,7 @@
 // Local headers
 #include "config.h"
 #include "dsp_pipeline.h"
+#include "flash_clkdiv.h"
 #include "flash_storage.h"
 #include "pico/audio_i2s_multi.h"
 #include "pdm_generator.h"
@@ -605,6 +606,11 @@ void core0_init() {
     if (!set_sys_clock_hz(307200000, false)) {
         set_sys_clock_hz(150000000, false);
     }
+
+    // Drop flash clock from ROM default (~102 MHz) to sys_clk/6 ≈ 51.2 MHz
+    // for parity with RP2040.  Subsequent flash ops go through the wrappers
+    // in flash_clkdiv.c which restore this after each erase/program.
+    dspi_flash_apply_clkdiv();
 #else
     vreg_set_voltage(VREG_VOLTAGE_1_15);
     busy_wait_ms(10);

--- a/firmware/DSPi/main.c
+++ b/firmware/DSPi/main.c
@@ -798,16 +798,26 @@ int main(void) {
                 complete_flash_write_operation_light();
             }
 
-            extern volatile bool flash_set_include_master_vol_pending;
-            if (flash_set_include_master_vol_pending) {
+            extern volatile bool flash_set_master_volume_mode_pending;
+            if (flash_set_master_volume_mode_pending) {
                 uint8_t val;
                 uint32_t f = save_and_disable_interrupts();
-                extern uint8_t flash_set_include_master_vol_val;
-                val = flash_set_include_master_vol_val;
-                flash_set_include_master_vol_pending = false;
+                extern uint8_t flash_set_master_volume_mode_val;
+                val = flash_set_master_volume_mode_val;
+                flash_set_master_volume_mode_pending = false;
                 restore_interrupts(f);
                 prepare_flash_write_operation();
-                preset_set_include_master_volume(val);
+                preset_set_master_volume_mode(val);
+                complete_flash_write_operation_light();
+            }
+
+            extern volatile bool flash_save_master_volume_pending;
+            if (flash_save_master_volume_pending) {
+                uint32_t f = save_and_disable_interrupts();
+                flash_save_master_volume_pending = false;
+                restore_interrupts(f);
+                prepare_flash_write_operation();
+                preset_save_master_volume();
                 complete_flash_write_operation_light();
             }
         }

--- a/firmware/DSPi/usb_audio.c
+++ b/firmware/DSPi/usb_audio.c
@@ -153,9 +153,13 @@ volatile float global_preamp_linear[NUM_INPUT_CHANNELS]   = {[0 ... NUM_INPUT_CH
 // does NOT affect loudness compensation, leveller, or any other DSP stage.
 // Range: MASTER_VOL_MIN_DB (-127) to MASTER_VOL_MAX_DB (0), with
 // MASTER_VOL_MUTE_DB (-128) as sentinel for true silence.
-volatile float master_volume_db       = MASTER_VOL_MAX_DB;   // 0 dB = unity (no attenuation)
-volatile float master_volume_linear   = 1.0f;
-volatile int32_t master_volume_q15    = 32768;                // Unity in Q15 (for RP2040 path)
+// Power-on defaults: -20 dB (MASTER_VOL_DEFAULT_DB).  linear = 10^(-20/20) = 0.1,
+// q15 = 0.1 × 32768 ≈ 3277.  These only matter for the tiny window between C
+// startup and preset_boot_load (which overwrites all three); kept consistent
+// with the dB field so nothing briefly mismatches.
+volatile float master_volume_db       = MASTER_VOL_DEFAULT_DB;
+volatile float master_volume_linear   = 0.1f;
+volatile int32_t master_volume_q15    = 3277;
 
 // Per-channel gain and mute (legacy 3-channel interface for flash compatibility)
 volatile float channel_gain_db[3] = {0.0f, 0.0f, 0.0f};

--- a/firmware/DSPi/usb_audio.c
+++ b/firmware/DSPi/usb_audio.c
@@ -103,9 +103,13 @@ uint8_t flash_set_startup_slot = 0;
 volatile bool flash_set_include_pins_pending = false;
 uint8_t flash_set_include_pins_val = 0;
 
-// Deferred include_master_volume directory update (flash write must happen on main loop)
-volatile bool flash_set_include_master_vol_pending = false;
-uint8_t flash_set_include_master_vol_val = 0;
+// Deferred master_volume_mode directory update (flash write must happen on main loop)
+volatile bool flash_set_master_volume_mode_pending = false;
+uint8_t flash_set_master_volume_mode_val = 0;
+
+// Deferred REQ_SAVE_MASTER_VOLUME — captures current live master_volume_db
+// into the directory's independent field.  Value is read at dispatch time.
+volatile bool flash_save_master_volume_pending = false;
 
 // 4 KB aligned buffer shared between GET and SET bulk param transfers.
 uint8_t __attribute__((aligned(4))) bulk_param_buf[WIRE_BULK_BUF_SIZE];
@@ -1904,15 +1908,24 @@ static void vendor_cmd_packet(struct usb_endpoint *ep) {
             break;
         }
 
-        case REQ_SET_INCLUDE_MASTER_VOL: {
-            // Set whether preset load restores master volume.
+        case REQ_SET_MASTER_VOLUME_MODE: {
+            // Set master-volume persistence mode (0 = independent, 1 = per-preset).
             // Deferred to main loop — flash write in dir_flush().
-            // Payload: 1 byte (0 = don't restore, 1 = restore on load).
             if (buffer->data_len >= 1) {
-                flash_set_include_master_vol_val = vendor_rx_buf[0];
+                uint8_t m = vendor_rx_buf[0];
+                if (m > MASTER_VOLUME_MODE_WITH_PRESET) m = MASTER_VOLUME_MODE_INDEPENDENT;
+                flash_set_master_volume_mode_val = m;
                 __dmb();
-                flash_set_include_master_vol_pending = true;
+                flash_set_master_volume_mode_pending = true;
             }
+            break;
+        }
+
+        case REQ_SAVE_MASTER_VOLUME: {
+            // Persist the current live master volume into the directory's
+            // independent field.  Accepted in both modes; dormant in mode 1.
+            // No payload — main-loop dispatcher reads live master_volume_db.
+            flash_save_master_volume_pending = true;
             break;
         }
 
@@ -2678,18 +2691,18 @@ static bool vendor_setup_request_handler(__unused struct usb_interface *interfac
                 //   [3]   default_slot
                 //   [4]   last_active_slot
                 //   [5]   include_pins
-                //   [6]   include_master_volume  (V12+, old apps request 6 bytes)
+                //   [6]   master_volume_mode (0 = independent, 1 = per-preset)
                 uint16_t occupied;
-                uint8_t mode, def_slot, last_active, inc_pins, inc_master_vol;
-                preset_get_directory(&occupied, &mode, &def_slot,
-                                     &last_active, &inc_pins, &inc_master_vol);
+                uint8_t startup, def_slot, last_active, inc_pins, mv_mode;
+                preset_get_directory(&occupied, &startup, &def_slot,
+                                     &last_active, &inc_pins, &mv_mode);
                 resp_buf[0] = occupied & 0xFF;
                 resp_buf[1] = occupied >> 8;
-                resp_buf[2] = mode;
+                resp_buf[2] = startup;
                 resp_buf[3] = def_slot;
                 resp_buf[4] = last_active;
                 resp_buf[5] = inc_pins;
-                resp_buf[6] = inc_master_vol;
+                resp_buf[6] = mv_mode;
                 vendor_send_response(resp_buf, 7);
                 return true;
             }
@@ -2697,10 +2710,10 @@ static bool vendor_setup_request_handler(__unused struct usb_interface *interfac
             case REQ_PRESET_GET_STARTUP: {
                 // Returns 3 bytes: startup_mode, default_slot, last_active
                 uint16_t occupied;
-                uint8_t mode, def_slot, last_active, inc_pins, inc_master_vol;
-                preset_get_directory(&occupied, &mode, &def_slot,
-                                     &last_active, &inc_pins, &inc_master_vol);
-                resp_buf[0] = mode;
+                uint8_t startup, def_slot, last_active, inc_pins, mv_mode;
+                preset_get_directory(&occupied, &startup, &def_slot,
+                                     &last_active, &inc_pins, &mv_mode);
+                resp_buf[0] = startup;
                 resp_buf[1] = def_slot;
                 resp_buf[2] = last_active;
                 vendor_send_response(resp_buf, 3);
@@ -2709,22 +2722,30 @@ static bool vendor_setup_request_handler(__unused struct usb_interface *interfac
 
             case REQ_PRESET_GET_INCLUDE_PINS: {
                 uint16_t occupied;
-                uint8_t mode, def_slot, last_active, inc_pins, inc_master_vol;
-                preset_get_directory(&occupied, &mode, &def_slot,
-                                     &last_active, &inc_pins, &inc_master_vol);
+                uint8_t startup, def_slot, last_active, inc_pins, mv_mode;
+                preset_get_directory(&occupied, &startup, &def_slot,
+                                     &last_active, &inc_pins, &mv_mode);
                 resp_buf[0] = inc_pins;
                 vendor_send_response(resp_buf, 1);
                 return true;
             }
 
-            case REQ_GET_INCLUDE_MASTER_VOL: {
-                // Returns whether preset load restores master volume (0/1).
+            case REQ_GET_MASTER_VOLUME_MODE: {
+                // Returns master-volume persistence mode (0 or 1).
                 uint16_t occupied;
-                uint8_t mode, def_slot, last_active, inc_pins, inc_master_vol;
-                preset_get_directory(&occupied, &mode, &def_slot,
-                                     &last_active, &inc_pins, &inc_master_vol);
-                resp_buf[0] = inc_master_vol;
+                uint8_t startup, def_slot, last_active, inc_pins, mv_mode;
+                preset_get_directory(&occupied, &startup, &def_slot,
+                                     &last_active, &inc_pins, &mv_mode);
+                resp_buf[0] = mv_mode;
                 vendor_send_response(resp_buf, 1);
+                return true;
+            }
+
+            case REQ_GET_SAVED_MASTER_VOLUME: {
+                // Returns the directory's independent master volume (mode 0 source).
+                float db = preset_get_saved_master_volume();
+                memcpy(resp_buf, &db, 4);
+                vendor_send_response(resp_buf, 4);
                 return true;
             }
 

--- a/firmware/DSPi/usb_audio.c
+++ b/firmware/DSPi/usb_audio.c
@@ -1921,14 +1921,6 @@ static void vendor_cmd_packet(struct usb_endpoint *ep) {
             break;
         }
 
-        case REQ_SAVE_MASTER_VOLUME: {
-            // Persist the current live master volume into the directory's
-            // independent field.  Accepted in both modes; dormant in mode 1.
-            // No payload — main-loop dispatcher reads live master_volume_db.
-            flash_save_master_volume_pending = true;
-            break;
-        }
-
         case REQ_SET_CHANNEL_NAME: {
             // wValue = channel index, payload = 1-32 bytes of name
             uint8_t ch = vendor_last_wValue & 0xFF;
@@ -2746,6 +2738,19 @@ static bool vendor_setup_request_handler(__unused struct usb_interface *interfac
                 float db = preset_get_saved_master_volume();
                 memcpy(resp_buf, &db, 4);
                 vendor_send_response(resp_buf, 4);
+                return true;
+            }
+
+            case REQ_SAVE_MASTER_VOLUME: {
+                // Action-style command: persist current live master volume into
+                // the directory's independent field.  Handled in the IN switch
+                // (matching REQ_FACTORY_RESET) so the host can issue a zero- or
+                // 1-byte-IN control transfer; responds with a 1-byte status so
+                // the transfer is shaped like other action commands.  The flash
+                // write itself is deferred to the main loop.
+                flash_save_master_volume_pending = true;
+                __dmb();
+                usb_start_tiny_control_in_transfer(PRESET_OK, 1);
                 return true;
             }
 

--- a/firmware/DSPi/usb_audio.c
+++ b/firmware/DSPi/usb_audio.c
@@ -589,20 +589,99 @@ static void __not_in_flash_func(process_audio_packet)(const uint8_t *data, uint1
 
     // ========== PASS 1: Input conversion + Preamp + Loudness ==========
     if (bit_depth == 24) {
-        const uint8_t *p = (const uint8_t *)data;
+        //     input 32 bit word to 24 bit output packing
+        //        in0     in1      in2
+        //     +-------+-------+-------+
+        //       (beware of l-endian)
+        //     +-----+-----+-----+-----+
+        //        l1    r1    l2    r2
+
+        const uint32_t *in = (const uint32_t *)data;
+        float *out_l = &buf_l[0], *out_r = &buf_r[0];
         const float inv_8388608 = 1.0f / 8388608.0f;
-        for (uint32_t i = 0; i < sample_count; i++) {
-            int32_t left  = (int32_t)((uint32_t)p[2] << 24 | (uint32_t)p[1] << 16 | (uint32_t)p[0] << 8) >> 8;
-            int32_t right = (int32_t)((uint32_t)p[5] << 24 | (uint32_t)p[4] << 16 | (uint32_t)p[3] << 8) >> 8;
-            buf_l[i] = (float)left * inv_8388608 * preamp_l;
-            buf_r[i] = (float)right * inv_8388608 * preamp_r;
-            p += 6;
+        const float gain_l = inv_8388608 * preamp_l;
+        const float gain_r = inv_8388608 * preamp_r;
+
+        //unpack 3 32bit words into 4 24 bit l,r,l,r samples
+        for (uint32_t i = 0; i < sample_count/2; i++) {
+            int32_t i0 = *in++;
+            int32_t i1 = *in++;
+            int32_t i2 = *in++;
+            int32_t temp;
+            float l1, l2, r1, r2;
+
+            __asm__ volatile (
+                "sbfx %[TEMP], %[I0], #0, #24\n\t"  //sign extend i0[23:0] to 32 bits
+                "vmov %[L1], %4\n\t"
+                "vcvt.f32.s32 %[L1], %[L1]\n\t"     // l1 result
+
+                "sxth %[TEMP], %[I1]\n\t"           // extract and sign extend halfword i1[15:0]
+                "lsl %[TEMP], %[TEMP], #8\n\t"      // shift left 8 bits
+                "asr %[I0], %[I0], #24\n\t"         // shift i0 right 24 bits
+                "bfi %[TEMP], %[I0], #0, #8\n\t"    // insert i0[7:0] into temp[7:0]
+                "vmov %[R1], %[TEMP]\n\t"
+                "vcvt.f32.s32 %[R1], %[R1]\n\t"     // r1 result
+
+                "asr %[TEMP], %[I1], #8\n\t"        // arithmetic shift right 8 bits i1
+                "bfi %[TEMP], %[I2], #24, #8\n\t"   // copy 8 lsb of i2 into temp[31:24]
+                "asr %[TEMP], %[TEMP], #8\n\t"      // arithmetic shift right temp left 8
+                "vmov %[L2], %[TEMP]\n\t"
+                "vcvt.f32.s32 %[L2], %[L2]\n\t"     // l2 result
+
+                "asr %[TEMP], %[I2], #8\n\t"        // arithmetic shift right i2[31:8] by 8 into temp
+                "vmov %[R2], %[TEMP]\n\t"
+                "vcvt.f32.s32 %[R2], %[R2]\n\t"     // r2 result
+
+                : [L1] "=w" (l1),
+                  [R1] "=w" (r1),
+                  [L2] "=w" (l2),
+                  [R2] "=w" (r2),
+                  [TEMP] "=&r" (temp)
+                : [I0] "r" (i0),
+                  [I1] "r" (i1),
+                  [I2] "r" (i2)
+            );
+
+            *out_l++ = l1 * gain_l;
+            *out_l++ = l2 * gain_l;
+            *out_r++ = r1 * gain_r;
+            *out_r++ = r2 * gain_r;
+        }
+        //if sample count is not divisible by 2 pick up the remaining l,r sample
+        if(sample_count % 2) {
+            int32_t i0 = *in++;
+            int32_t i1 = *in++;
+            int32_t temp;
+            float l1, r1;
+
+            __asm__ volatile (
+                "sbfx %[TEMP], %[I0], #0, #24\n\t"  //sign extend i0[23:0] to 32 bits
+                "vmov %[L1], %[TEMP]\n\t"
+                "vcvt.f32.s32 %[L1], %[L1]\n\t"     // l1 result
+
+                "sxth %[TEMP], %[I1]\n\t"           // extract and sign extend halfword i1[15:0]
+                "lsl %[TEMP], %[TEMP], #8\n\t"      // shift left 8 bits
+                "asr %[I0], %[I0], #24\n\t"         // shift i0 right 24 bits
+                "bfi %[TEMP], %[I0], #0, #8\n\t"    // insert i0[7:0] into temp[7:0]
+                "vmov %[R1], %[TEMP]\n\t"
+                "vcvt.f32.s32 %[R1], %[R1]\n\t"     // r1 result
+
+                : [L1] "=w" (l1),
+                  [R1] "=w" (r1),
+                  [TEMP] "=&r" (temp)
+                : [I0] "r" (i0),
+                  [I1] "r" (i1)
+            );
+            *out_l++ = l1 * gain_l;
+            *out_r++ = r1 * gain_r;
         }
     } else {
         const int16_t *in = (const int16_t *)data;
+        float gain_l = inv_32768 * preamp_l;
+        float gain_r = inv_32768 * preamp_r;
         for (uint32_t i = 0; i < sample_count; i++) {
-            buf_l[i] = (float)in[i*2] * inv_32768 * preamp_l;
-            buf_r[i] = (float)in[i*2+1] * inv_32768 * preamp_r;
+            buf_l[i] = (float)in[i*2] * gain_l;
+            buf_r[i] = (float)in[i*2+1] * gain_r;
         }
     }
 


### PR DESCRIPTION
The documentation for `REQ_GET_EQ_PARAM (0x43)` describes a 16-byte IN transfer that returns a full filter packet, but the firmware returns **one parameter per request (4 bytes each)** using a `param` sub-field in `wValue`. This discrepancy causes host implementations built from the docs to receive garbage data.

From [`firmware/DSPi/usb_audio.c`](https://github.com/WeebLabs/DSPi/blob/main/firmware/DSPi/usb_audio.c):

```c
case REQ_GET_EQ_PARAM: {
    uint8_t channel = (setup->wValue >> 8) & 0xFF;
    uint8_t band    = (setup->wValue >> 4) & 0x0F;
    uint8_t param   = setup->wValue & 0x0F;
    if (channel < NUM_CHANNELS && band < channel_band_counts[channel]) {
        uint32_t val_to_send = 0;
        EqParamPacket *p = &filter_recipes[channel][band];
        switch (param) {
            case 0: val_to_send = (uint32_t)p->type; break;
            case 1: memcpy(&val_to_send, &p->freq, 4); break;
            case 2: memcpy(&val_to_send, &p->Q, 4); break;
            case 3: memcpy(&val_to_send, &p->gain_db, 4); break;
        }
        usb_start_tiny_control_in_transfer(val_to_send, 4);
        return true;
    }
    return false;
}
```

- `wValue` encoding: `(channel << 8) | (band << 4) | param`
- Payload returned: **4 bytes** (not 16)
- Four requests are required to read a full band

This PR updates the documentation to match the firmware's actual wire format.
